### PR TITLE
[#23] Resident registration handler + Location Service place index

### DIFF
--- a/functions/alert/register.py
+++ b/functions/alert/register.py
@@ -31,6 +31,7 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 
 import boto3
+from botocore.exceptions import ClientError
 
 E164_RE = re.compile(r"^\+[1-9]\d{1,14}$")
 DEFAULT_ALERT_RADIUS_KM = Decimal("10")
@@ -74,17 +75,30 @@ def _to_decimal(value) -> Decimal:
     return Decimal(str(value))
 
 
+class GeocodeError(Exception):
+    """Raised by _geocode for any failure. Carries an HTTP status hint."""
+
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.status = status
+
+
 def _geocode(address: str) -> tuple[Decimal, Decimal]:
     """Geocode an address via AWS Location Service. Returns (lat, lon)."""
     index = os.environ.get("WW_LOCATION_PLACE_INDEX")
     if not index:
-        raise ValueError("server-side geocoding unavailable (WW_LOCATION_PLACE_INDEX unset)")
-    resp = _location().search_place_index_for_text(
-        IndexName=index, Text=address, MaxResults=1
-    )
+        raise GeocodeError("server-side geocoding unavailable (WW_LOCATION_PLACE_INDEX unset)")
+    try:
+        resp = _location().search_place_index_for_text(
+            IndexName=index, Text=address, MaxResults=1
+        )
+    except ClientError:
+        # Don't leak AWS error details to the API response. CloudWatch will
+        # have the full ClientError trace from boto3 for debugging.
+        raise GeocodeError("geocoding service unavailable", status=502)
     results = resp.get("Results", [])
     if not results:
-        raise ValueError("no geocoding match for address")
+        raise GeocodeError("no geocoding match for address")
     # Location Service returns Point as [longitude, latitude] (GeoJSON order).
     lon, lat = results[0]["Place"]["Geometry"]["Point"]
     return _to_decimal(lat), _to_decimal(lon)
@@ -93,10 +107,13 @@ def _geocode(address: str) -> tuple[Decimal, Decimal]:
 def _resolve_location(body: dict) -> tuple[Decimal, Decimal] | dict:
     """Return (lat, lon) on success, or an error response dict on failure."""
     if "address" in body:
+        address = body["address"]
+        if not isinstance(address, str) or not address.strip():
+            return _response(400, {"error": "address must be a non-empty string"})
         try:
-            return _geocode(body["address"])
-        except ValueError as e:
-            return _response(400, {"error": str(e)})
+            return _geocode(address)
+        except GeocodeError as e:
+            return _response(e.status, {"error": str(e)})
 
     if "lat" in body and "lon" in body:
         try:
@@ -116,6 +133,8 @@ def handler(event, context=None):
         body = json.loads(event.get("body") or "{}")
     except json.JSONDecodeError:
         return _response(400, {"error": "invalid JSON body"})
+    if not isinstance(body, dict):
+        return _response(400, {"error": "body must be a JSON object"})
 
     phone = body.get("phone")
     if not phone or not isinstance(phone, str) or not E164_RE.match(phone):

--- a/functions/alert/register.py
+++ b/functions/alert/register.py
@@ -1,0 +1,154 @@
+"""Resident registration Lambda handler (#23).
+
+POST /residents/register
+
+Auth: API Gateway's Cognito authorizer verifies the JWT and attaches
+verified claims to ``event.requestContext.authorizer.claims``. We trust
+those claims (the authorizer rejects malformed tokens upstream) and use
+``sub`` as the ``resident_id``.
+
+Body schema (JSON):
+  {
+    "phone": "+15555550100",         # required, E.164
+    "address": "123 Main St, ...",   # optional - server-geocoded if present
+    "lat": 37.7749,                  # alternative to address
+    "lon": -122.4194,
+    "alert_radius_km": 10            # optional, default 10
+  }
+
+Either ``address`` or ``lat``+``lon`` must be provided. Frontends that
+already use Mapbox can geocode in-browser and skip the server round-trip.
+
+PII handling: phone numbers are written to DynamoDB (encrypted at rest by
+the table's AWS-owned KMS key) and NEVER logged to CloudWatch. Only the
+opaque Cognito ``sub`` is logged.
+"""
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+
+import boto3
+
+E164_RE = re.compile(r"^\+[1-9]\d{1,14}$")
+DEFAULT_ALERT_RADIUS_KM = Decimal("10")
+MAX_ALERT_RADIUS_KM = Decimal("100")
+
+_dynamodb = boto3.resource("dynamodb")
+_location_client = None
+
+
+def _table():
+    return _dynamodb.Table(os.environ["WW_DYNAMODB_RESIDENTS_TABLE"])
+
+
+def _location():
+    global _location_client
+    if _location_client is None:
+        _location_client = boto3.client("location")
+    return _location_client
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _response(status: int, body: dict) -> dict:
+    return {
+        "statusCode": status,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _resident_id(event: dict) -> str | None:
+    try:
+        return event["requestContext"]["authorizer"]["claims"]["sub"]
+    except (KeyError, TypeError):
+        return None
+
+
+def _to_decimal(value) -> Decimal:
+    return Decimal(str(value))
+
+
+def _geocode(address: str) -> tuple[Decimal, Decimal]:
+    """Geocode an address via AWS Location Service. Returns (lat, lon)."""
+    index = os.environ.get("WW_LOCATION_PLACE_INDEX")
+    if not index:
+        raise ValueError("server-side geocoding unavailable (WW_LOCATION_PLACE_INDEX unset)")
+    resp = _location().search_place_index_for_text(
+        IndexName=index, Text=address, MaxResults=1
+    )
+    results = resp.get("Results", [])
+    if not results:
+        raise ValueError("no geocoding match for address")
+    # Location Service returns Point as [longitude, latitude] (GeoJSON order).
+    lon, lat = results[0]["Place"]["Geometry"]["Point"]
+    return _to_decimal(lat), _to_decimal(lon)
+
+
+def _resolve_location(body: dict) -> tuple[Decimal, Decimal] | dict:
+    """Return (lat, lon) on success, or an error response dict on failure."""
+    if "address" in body:
+        try:
+            return _geocode(body["address"])
+        except ValueError as e:
+            return _response(400, {"error": str(e)})
+
+    if "lat" in body and "lon" in body:
+        try:
+            return _to_decimal(body["lat"]), _to_decimal(body["lon"])
+        except (InvalidOperation, TypeError):
+            return _response(400, {"error": "lat/lon must be numeric"})
+
+    return _response(400, {"error": "must provide either 'address' or 'lat'+'lon'"})
+
+
+def handler(event, context=None):
+    resident_id = _resident_id(event)
+    if not resident_id:
+        return _response(401, {"error": "unauthorized"})
+
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return _response(400, {"error": "invalid JSON body"})
+
+    phone = body.get("phone")
+    if not phone or not isinstance(phone, str) or not E164_RE.match(phone):
+        return _response(400, {"error": "phone must be E.164 format (+1...)"})
+
+    location = _resolve_location(body)
+    if isinstance(location, dict):  # error response
+        return location
+    lat, lon = location
+
+    if not (Decimal("-90") <= lat <= Decimal("90")):
+        return _response(400, {"error": "lat out of range [-90, 90]"})
+    if not (Decimal("-180") <= lon <= Decimal("180")):
+        return _response(400, {"error": "lon out of range [-180, 180]"})
+
+    try:
+        radius = _to_decimal(body.get("alert_radius_km", DEFAULT_ALERT_RADIUS_KM))
+    except (InvalidOperation, TypeError):
+        return _response(400, {"error": "alert_radius_km must be numeric"})
+    if radius <= 0 or radius > MAX_ALERT_RADIUS_KM:
+        return _response(400, {"error": f"alert_radius_km must be in (0, {MAX_ALERT_RADIUS_KM}]"})
+
+    _table().put_item(
+        Item={
+            "resident_id": resident_id,
+            "phone": phone,
+            "lat": lat,
+            "lon": lon,
+            "alert_radius_km": radius,
+            "registered_at": _now(),
+        }
+    )
+
+    # PII rule: never log the phone number. resident_id is an opaque Cognito sub.
+    print(f"resident registered: {resident_id}")
+    return _response(201, {"resident_id": resident_id})

--- a/infrastructure/stacks/frontend_stack.py
+++ b/infrastructure/stacks/frontend_stack.py
@@ -7,6 +7,7 @@ from aws_cdk import (
     aws_apigateway as apigw,
     aws_apigatewayv2 as apigwv2,
     aws_amplify as amplify,
+    aws_location as location,
 )
 from constructs import Construct
 
@@ -39,6 +40,7 @@ class FrontendStack(Stack):
         self._provision_rest_api()
         self._provision_websocket_api()
         self._provision_amplify()
+        self._provision_location()
 
     # ------------------------------------------------------------------
     # Cognito — resident + dispatcher pools
@@ -184,4 +186,24 @@ class FrontendStack(Stack):
         CfnOutput(self, "AmplifyAppId",
             value=self.amplify_app.attr_app_id,
             export_name="WildfireWatch::Frontend::AmplifyAppId",
+        )
+
+    # ------------------------------------------------------------------
+    # Location Service - server-side geocoding for resident registration (#23)
+    # ------------------------------------------------------------------
+
+    def _provision_location(self):
+        # Esri data source is fine for the hackathon - free tier covers
+        # demo-scale geocode volume. Switch to Here if we need POI search later.
+        self.place_index = location.CfnPlaceIndex(
+            self, "PlaceIndex",
+            index_name="wildfire-watch-places",
+            data_source="Esri",
+            description="Geocoder for resident registration addresses",
+        )
+
+        CfnOutput(self, "PlaceIndexName",
+            value=self.place_index.index_name,
+            export_name="WildfireWatch::Frontend::PlaceIndexName",
+            description="Env var: WW_LOCATION_PLACE_INDEX",
         )

--- a/tests/unit/test_register.py
+++ b/tests/unit/test_register.py
@@ -1,0 +1,193 @@
+"""Unit tests for the resident registration handler (#23)."""
+
+import json
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+TABLE_NAME = "residents-test"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("WW_DYNAMODB_RESIDENTS_TABLE", TABLE_NAME)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+    yield
+
+
+@pytest.fixture
+def residents_table(env):
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-west-2")
+        client.create_table(
+            TableName=TABLE_NAME,
+            KeySchema=[{"AttributeName": "resident_id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "resident_id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield boto3.resource("dynamodb", region_name="us-west-2").Table(TABLE_NAME)
+
+
+@pytest.fixture
+def register(env):
+    """Reload the module under each test so the cached dynamodb resource
+    binds to the moto-mocked endpoint, not a real one from a prior test."""
+    import importlib
+
+    from functions.alert import register as module
+
+    importlib.reload(module)
+    return module
+
+
+def _event(body: dict | str | None, sub: str | None = "user-abc-123") -> dict:
+    return {
+        "body": body if isinstance(body, str) or body is None else json.dumps(body),
+        "requestContext": {
+            "authorizer": {"claims": {"sub": sub}} if sub else {}
+        },
+    }
+
+
+def test_register_with_lat_lon_writes_row(residents_table, register):
+    event = _event({"phone": "+15555550100", "lat": 37.7749, "lon": -122.4194})
+    resp = register.handler(event)
+    assert resp["statusCode"] == 201
+    assert json.loads(resp["body"]) == {"resident_id": "user-abc-123"}
+
+    item = residents_table.get_item(Key={"resident_id": "user-abc-123"})["Item"]
+    assert item["phone"] == "+15555550100"
+    assert item["lat"] == Decimal("37.7749")
+    assert item["lon"] == Decimal("-122.4194")
+    assert item["alert_radius_km"] == Decimal("10")  # default
+    assert "registered_at" in item
+
+
+def test_register_with_address_geocodes_via_location(residents_table, register, monkeypatch):
+    monkeypatch.setenv("WW_LOCATION_PLACE_INDEX", "test-index")
+    fake_location = MagicMock()
+    fake_location.search_place_index_for_text.return_value = {
+        "Results": [
+            {"Place": {"Geometry": {"Point": [-122.4194, 37.7749]}}}  # [lon, lat]
+        ]
+    }
+    with patch.object(register, "_location", return_value=fake_location):
+        event = _event({"phone": "+15555550100", "address": "1 Market St, SF, CA"})
+        resp = register.handler(event)
+
+    assert resp["statusCode"] == 201
+    item = residents_table.get_item(Key={"resident_id": "user-abc-123"})["Item"]
+    assert item["lat"] == Decimal("37.7749")
+    assert item["lon"] == Decimal("-122.4194")
+    fake_location.search_place_index_for_text.assert_called_once_with(
+        IndexName="test-index", Text="1 Market St, SF, CA", MaxResults=1
+    )
+
+
+def test_register_address_without_place_index_env_returns_400(residents_table, register):
+    # WW_LOCATION_PLACE_INDEX intentionally unset
+    event = _event({"phone": "+15555550100", "address": "1 Market St"})
+    resp = register.handler(event)
+    assert resp["statusCode"] == 400
+    assert "geocoding unavailable" in json.loads(resp["body"])["error"]
+
+
+def test_register_address_no_match_returns_400(residents_table, register, monkeypatch):
+    monkeypatch.setenv("WW_LOCATION_PLACE_INDEX", "test-index")
+    fake_location = MagicMock()
+    fake_location.search_place_index_for_text.return_value = {"Results": []}
+    with patch.object(register, "_location", return_value=fake_location):
+        event = _event({"phone": "+15555550100", "address": "nowhere at all"})
+        resp = register.handler(event)
+    assert resp["statusCode"] == 400
+    assert "no geocoding match" in json.loads(resp["body"])["error"]
+
+
+def test_register_rejects_missing_auth(residents_table, register):
+    event = _event({"phone": "+15555550100", "lat": 37.7, "lon": -122.4}, sub=None)
+    resp = register.handler(event)
+    assert resp["statusCode"] == 401
+
+
+def test_register_rejects_invalid_phone(residents_table, register):
+    for bad in ["5555550100", "+", "+1", "not-a-phone", "", None]:
+        event = _event({"phone": bad, "lat": 37.7, "lon": -122.4})
+        resp = register.handler(event)
+        assert resp["statusCode"] == 400, f"should reject phone={bad!r}"
+        assert "E.164" in json.loads(resp["body"])["error"]
+
+
+def test_register_rejects_missing_location(residents_table, register):
+    event = _event({"phone": "+15555550100"})  # no address, no lat/lon
+    resp = register.handler(event)
+    assert resp["statusCode"] == 400
+    assert "address" in json.loads(resp["body"])["error"]
+
+
+def test_register_rejects_out_of_range_lat(residents_table, register):
+    event = _event({"phone": "+15555550100", "lat": 91, "lon": 0})
+    resp = register.handler(event)
+    assert resp["statusCode"] == 400
+    assert "lat out of range" in json.loads(resp["body"])["error"]
+
+
+def test_register_rejects_out_of_range_lon(residents_table, register):
+    event = _event({"phone": "+15555550100", "lat": 0, "lon": -181})
+    resp = register.handler(event)
+    assert resp["statusCode"] == 400
+    assert "lon out of range" in json.loads(resp["body"])["error"]
+
+
+def test_register_rejects_invalid_json(residents_table, register):
+    event = _event("{not-json")
+    resp = register.handler(event)
+    assert resp["statusCode"] == 400
+    assert "invalid JSON" in json.loads(resp["body"])["error"]
+
+
+def test_register_rejects_negative_radius(residents_table, register):
+    event = _event({"phone": "+15555550100", "lat": 37.7, "lon": -122.4, "alert_radius_km": -1})
+    resp = register.handler(event)
+    assert resp["statusCode"] == 400
+
+
+def test_register_rejects_oversized_radius(residents_table, register):
+    event = _event({"phone": "+15555550100", "lat": 37.7, "lon": -122.4, "alert_radius_km": 1000})
+    resp = register.handler(event)
+    assert resp["statusCode"] == 400
+
+
+def test_register_accepts_custom_radius(residents_table, register):
+    event = _event({"phone": "+15555550100", "lat": 37.7, "lon": -122.4, "alert_radius_km": 25})
+    resp = register.handler(event)
+    assert resp["statusCode"] == 201
+    item = residents_table.get_item(Key={"resident_id": "user-abc-123"})["Item"]
+    assert item["alert_radius_km"] == Decimal("25")
+
+
+def test_register_does_not_log_phone(residents_table, register, capsys):
+    # PII rule: phone must never appear in logs.
+    phone = "+15555550199"
+    event = _event({"phone": phone, "lat": 37.7, "lon": -122.4})
+    resp = register.handler(event)
+    assert resp["statusCode"] == 201
+    captured = capsys.readouterr()
+    assert phone not in captured.out
+    assert phone not in captured.err
+    # But the opaque resident_id IS expected in logs (for audit/debug).
+    assert "user-abc-123" in captured.out
+
+
+def test_register_overwrites_existing_resident(residents_table, register):
+    # Re-registration should update, not duplicate. resident_id is the PK.
+    event1 = _event({"phone": "+15555550100", "lat": 37.7, "lon": -122.4})
+    event2 = _event({"phone": "+15555550200", "lat": 40.0, "lon": -120.0})
+    register.handler(event1)
+    register.handler(event2)
+    item = residents_table.get_item(Key={"resident_id": "user-abc-123"})["Item"]
+    assert item["phone"] == "+15555550200"
+    assert item["lat"] == Decimal("40.0")

--- a/tests/unit/test_register.py
+++ b/tests/unit/test_register.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 TABLE_NAME = "residents-test"
@@ -191,3 +192,149 @@ def test_register_overwrites_existing_resident(residents_table, register):
     item = residents_table.get_item(Key={"resident_id": "user-abc-123"})["Item"]
     assert item["phone"] == "+15555550200"
     assert item["lat"] == Decimal("40.0")
+
+
+# ---------------------------------------------------------------------------
+# Defensive parsing: malformed inputs that previously crashed the handler.
+# ---------------------------------------------------------------------------
+
+
+def test_register_rejects_non_dict_json_body(residents_table, register):
+    # Valid JSON but not an object - null, arrays, scalars used to crash with
+    # AttributeError because the handler called .get() on them.
+    for raw in ("null", "[1,2,3]", "42", '"hello"'):
+        event = _event(raw)
+        resp = register.handler(event)
+        assert resp["statusCode"] == 400, f"should reject body={raw!r}"
+        assert "JSON object" in json.loads(resp["body"])["error"]
+
+
+def test_register_rejects_empty_address(residents_table, register, monkeypatch):
+    # Previously fell through to Location Service which raised an uncaught
+    # ClientError. Now caught locally before any AWS call.
+    monkeypatch.setenv("WW_LOCATION_PLACE_INDEX", "test-index")
+    fake_location = MagicMock()
+    with patch.object(register, "_location", return_value=fake_location):
+        for empty in ("", "   ", "\t\n"):
+            event = _event({"phone": "+15555550100", "address": empty})
+            resp = register.handler(event)
+            assert resp["statusCode"] == 400, f"should reject address={empty!r}"
+            assert "non-empty" in json.loads(resp["body"])["error"]
+    fake_location.search_place_index_for_text.assert_not_called()
+
+
+def test_register_rejects_non_string_address(residents_table, register, monkeypatch):
+    monkeypatch.setenv("WW_LOCATION_PLACE_INDEX", "test-index")
+    fake_location = MagicMock()
+    with patch.object(register, "_location", return_value=fake_location):
+        event = _event({"phone": "+15555550100", "address": {"street": "Main"}})
+        resp = register.handler(event)
+    assert resp["statusCode"] == 400
+    fake_location.search_place_index_for_text.assert_not_called()
+
+
+def test_register_geocoder_client_error_returns_502(residents_table, register, monkeypatch):
+    # AWS Location Service throwing a ClientError (throttling, missing index,
+    # transient outage) must not crash the handler.
+    monkeypatch.setenv("WW_LOCATION_PLACE_INDEX", "test-index")
+    fake_location = MagicMock()
+    fake_location.search_place_index_for_text.side_effect = ClientError(
+        {"Error": {"Code": "ThrottlingException", "Message": "rate exceeded"}},
+        "SearchPlaceIndexForText",
+    )
+    with patch.object(register, "_location", return_value=fake_location):
+        event = _event({"phone": "+15555550100", "address": "1 Market St"})
+        resp = register.handler(event)
+    assert resp["statusCode"] == 502
+    body = json.loads(resp["body"])
+    # Must NOT leak the AWS error code or message
+    assert "ThrottlingException" not in body["error"]
+    assert "rate exceeded" not in body["error"]
+    assert "geocoding" in body["error"]
+
+
+def test_register_handles_missing_request_context(residents_table, register):
+    # Defensive: a Lambda invocation with no requestContext (e.g. invoked
+    # directly outside API Gateway) should reject cleanly rather than 500.
+    resp = register.handler({"body": json.dumps({"phone": "+15555550100", "lat": 0, "lon": 0})})
+    assert resp["statusCode"] == 401
+
+
+# ---------------------------------------------------------------------------
+# Boundary cases - the most likely places off-by-one bugs hide.
+# ---------------------------------------------------------------------------
+
+
+def test_register_accepts_lat_lon_at_exact_boundaries(residents_table, register):
+    # ±90 lat and ±180 lon are valid coordinates (poles, antimeridian).
+    for lat, lon in [(90, 0), (-90, 0), (0, 180), (0, -180), (90, 180), (-90, -180)]:
+        event = _event({"phone": "+15555550100", "lat": lat, "lon": lon})
+        resp = register.handler(event)
+        assert resp["statusCode"] == 201, f"should accept lat={lat}, lon={lon}"
+
+
+def test_register_rejects_just_outside_lat_lon_boundaries(residents_table, register):
+    for lat, lon, who in [(90.0001, 0, "lat"), (-90.0001, 0, "lat"),
+                          (0, 180.0001, "lon"), (0, -180.0001, "lon")]:
+        event = _event({"phone": "+15555550100", "lat": lat, "lon": lon})
+        resp = register.handler(event)
+        assert resp["statusCode"] == 400, f"should reject lat={lat}, lon={lon}"
+        assert who in json.loads(resp["body"])["error"]
+
+
+def test_register_radius_boundaries(residents_table, register):
+    # 0 rejected (must be > 0); 100 accepted (must be <= 100).
+    for radius, expected in [(0, 400), (0.0001, 201), (100, 201), (100.0001, 400)]:
+        event = _event(
+            {"phone": "+15555550100", "lat": 37.7, "lon": -122.4, "alert_radius_km": radius}
+        )
+        resp = register.handler(event)
+        assert resp["statusCode"] == expected, f"radius={radius} expected {expected}"
+
+
+def test_register_rejects_non_numeric_lat_lon(residents_table, register):
+    # Strings, booleans, dicts as lat/lon should 400, not crash.
+    for lat, lon in [("not-a-number", 0), (0, "nope"), ([1, 2], 0)]:
+        event = _event({"phone": "+15555550100", "lat": lat, "lon": lon})
+        resp = register.handler(event)
+        assert resp["statusCode"] == 400, f"should reject lat={lat!r}, lon={lon!r}"
+
+
+def test_register_rejects_non_numeric_radius(residents_table, register):
+    event = _event(
+        {"phone": "+15555550100", "lat": 37.7, "lon": -122.4, "alert_radius_km": "ten"}
+    )
+    resp = register.handler(event)
+    assert resp["statusCode"] == 400
+    assert "numeric" in json.loads(resp["body"])["error"]
+
+
+def test_register_extra_fields_ignored(residents_table, register):
+    # Forward-compatibility: unknown fields should be silently ignored, not
+    # cause the request to fail. Lets the frontend send extras during dev.
+    event = _event({
+        "phone": "+15555550100",
+        "lat": 37.7,
+        "lon": -122.4,
+        "favorite_color": "blue",
+        "nested": {"x": 1},
+    })
+    resp = register.handler(event)
+    assert resp["statusCode"] == 201
+    item = residents_table.get_item(Key={"resident_id": "user-abc-123"})["Item"]
+    assert "favorite_color" not in item
+    assert "nested" not in item
+
+
+def test_register_does_not_log_phone_on_address_path(residents_table, register, capsys, monkeypatch):
+    # The PII-no-log contract holds even on error paths in the address branch.
+    monkeypatch.setenv("WW_LOCATION_PLACE_INDEX", "test-index")
+    phone = "+15555550199"
+    fake_location = MagicMock()
+    fake_location.search_place_index_for_text.return_value = {"Results": []}
+    with patch.object(register, "_location", return_value=fake_location):
+        event = _event({"phone": phone, "address": "nowhere"})
+        register.handler(event)
+    captured = capsys.readouterr()
+    assert phone not in captured.out
+    assert phone not in captured.err


### PR DESCRIPTION
## Summary
- `functions/alert/register.py` — Lambda handler for `POST /residents/register`
- API Gateway's Cognito authorizer attaches verified claims to the event; the handler trusts them and uses `sub` as `resident_id` (no in-Lambda JWT verify)
- Body accepts E.164 phone + either an `address` (server-geocoded via AWS Location Service) or pre-resolved `lat`/`lon` for frontends that geocode in-browser via Mapbox
- Adds `AWS::Location::PlaceIndex` (Esri data source, free tier) to `FrontendStack` so server-side geocoding has a target
- Honors the CLAUDE.md PII rule: phone numbers go to DynamoDB (encrypted at rest by AWS-owned KMS) and never appear in CloudWatch logs

## Why this shape
- Address vs. lat/lon flexibility avoids forcing every client through Location Service when Mapbox is already loaded for the map
- Cognito authorizer claims (vs. JWT decoding in Lambda) keeps the handler small and pushes JWKS rotation onto API Gateway
- Place index lives in `FrontendStack` next to Cognito and API Gateway since it's user-facing infra

## Test plan
- [x] 15 unit tests in `tests/unit/test_register.py` — all passing
  - lat/lon write path
  - address geocoding path (mocked Location client)
  - missing place index env, no geocoding match
  - rejected: missing auth, invalid phone (6 cases), missing location, out-of-range lat/lon, invalid JSON, negative/oversized radius
  - custom radius accepted
  - phone never logged (capsys assertion) — PII contract test
  - re-registration overwrites (resident_id is PK)
- [x] CDK synth verified: `AWS::Location::PlaceIndex` resource generated correctly with Esri data source

## Follow-ups
- API Gateway route + Lambda integration (separate infra wiring; this PR ships the handler + place index resource)
- Frontend UI in #29 will consume this endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)