### PR TITLE
[#21] Safety gate Lambda - orchestrates Bedrock + audit + guardrails + confidence

### DIFF
--- a/functions/alert/safety_gate.py
+++ b/functions/alert/safety_gate.py
@@ -1,0 +1,84 @@
+"""Safety gate Lambda (#21) - the single choke point before SNS dispatch.
+
+Every advisory passes through here. The order of operations is the safety
+contract; reordering breaks #32.
+
+  1. Generate advisory via Bedrock (``ml.bedrock.advisory_prompt``)
+  2. Append the prediction row to the audit hash-chain
+     (``functions.alert.audit.log_prediction``). MUST commit before the
+     guardrail call so even blocked advisories leave an auditable record
+     of what was generated.
+  3. Validate via Bedrock Guardrails (``ml.bedrock.guardrails``)
+  4. Append a ``guardrails_outcome`` row linked to the prediction
+     (never mutate the prior row - that breaks the SHA-256 chain)
+  5. Confidence threshold check
+
+Output - Step Functions (#19) routes on ``action``:
+
+  {
+    "action": "APPROVED" | "HUMAN_REVIEW_REQUIRED" | "BLOCKED",
+    "prediction_id": str,
+    "advisory": {"sms": str, "brief": str},   # APPROVED + HUMAN_REVIEW
+    "blocked_reason": str | None,             # BLOCKED
+  }
+
+Why the third action: a guardrails block isn't human-fixable - the
+advisory itself is unsafe. HUMAN_REVIEW_REQUIRED is for the orthogonal
+case where the advisory is safe but model confidence is low.
+
+Failure semantics: if Bedrock advisory generation raises, NO audit row
+is written - nothing safety-relevant happened. If ``log_prediction``
+raises, the function halts (no guardrail call attempted) - we never
+proceed past step 2 without a committed audit row.
+"""
+
+import os
+
+from functions.alert.audit import append_guardrail_outcome, log_prediction
+from ml.bedrock.advisory_prompt import generate_advisory
+from ml.bedrock.guardrails import validate_advisory
+
+DEFAULT_CONFIDENCE_THRESHOLD = 0.65
+
+
+def handler(event, context=None):
+    fire_event = event["fire_event"]
+    recommendation = event["recommendation"]
+    threshold = float(
+        os.environ.get("WW_CONFIDENCE_THRESHOLD", DEFAULT_CONFIDENCE_THRESHOLD)
+    )
+
+    advisory = generate_advisory(fire_event, recommendation)
+
+    prediction_id = log_prediction(fire_event["fire_id"], recommendation, advisory)
+
+    guardrail_result = validate_advisory(
+        advisory["sms"], confidence=recommendation["confidence"]
+    )
+
+    append_guardrail_outcome(
+        fire_event["fire_id"],
+        prediction_id,
+        passed=guardrail_result["passed"],
+        reason=guardrail_result.get("blocked_reason"),
+    )
+
+    if not guardrail_result["passed"]:
+        return {
+            "action": "BLOCKED",
+            "prediction_id": prediction_id,
+            "blocked_reason": guardrail_result["blocked_reason"],
+        }
+
+    if recommendation["confidence"] < threshold:
+        return {
+            "action": "HUMAN_REVIEW_REQUIRED",
+            "prediction_id": prediction_id,
+            "advisory": advisory,
+        }
+
+    return {
+        "action": "APPROVED",
+        "prediction_id": prediction_id,
+        "advisory": advisory,
+    }

--- a/functions/alert/safety_gate.py
+++ b/functions/alert/safety_gate.py
@@ -3,15 +3,16 @@
 Every advisory passes through here. The order of operations is the safety
 contract; reordering breaks #32.
 
-  1. Generate advisory via Bedrock (``ml.bedrock.advisory_prompt``)
-  2. Append the prediction row to the audit hash-chain
+  1. Validate input shape (clear errors for Step Functions to surface)
+  2. Generate advisory via Bedrock (``ml.bedrock.advisory_prompt``)
+  3. Append the prediction row to the audit hash-chain
      (``functions.alert.audit.log_prediction``). MUST commit before the
      guardrail call so even blocked advisories leave an auditable record
      of what was generated.
-  3. Validate via Bedrock Guardrails (``ml.bedrock.guardrails``)
-  4. Append a ``guardrails_outcome`` row linked to the prediction
+  4. Validate via Bedrock Guardrails (``ml.bedrock.guardrails``)
+  5. Append a ``guardrails_outcome`` row linked to the prediction
      (never mutate the prior row - that breaks the SHA-256 chain)
-  5. Confidence threshold check
+  6. Confidence threshold check
 
 Output - Step Functions (#19) routes on ``action``:
 
@@ -22,14 +23,25 @@ Output - Step Functions (#19) routes on ``action``:
     "blocked_reason": str | None,             # BLOCKED
   }
 
-Why the third action: a guardrails block isn't human-fixable - the
-advisory itself is unsafe. HUMAN_REVIEW_REQUIRED is for the orthogonal
-case where the advisory is safe but model confidence is low.
+Why three actions: a guardrails block isn't human-fixable - the advisory
+itself is unsafe. HUMAN_REVIEW_REQUIRED is for the orthogonal case where
+the advisory is safe but model confidence is low.
 
-Failure semantics: if Bedrock advisory generation raises, NO audit row
-is written - nothing safety-relevant happened. If ``log_prediction``
-raises, the function halts (no guardrail call attempted) - we never
-proceed past step 2 without a committed audit row.
+Failure semantics:
+  * Bad input -> raise ValueError with a clear message; no audit row.
+  * Bedrock advisory generation raises -> propagate; no audit row.
+  * log_prediction raises -> propagate; halt before guardrails. The
+    audit contract requires the row be committed before any
+    safety-relevant downstream action.
+  * validate_advisory raises (Bedrock outage, throttling) -> append a
+    ``guardrails_outcome`` row marked ``passed=False`` with an error
+    reason, THEN re-raise. This keeps the audit chain forensically
+    complete even when the validation service is down - otherwise
+    Step Functions retries pile up orphan prediction rows with no
+    outcome to explain them.
+  * append_guardrail_outcome raising -> propagate; the prediction is
+    already committed so the chain is intact, just incomplete. Rare;
+    Step Functions retry will produce a clean chain.
 """
 
 import os
@@ -41,20 +53,55 @@ from ml.bedrock.guardrails import validate_advisory
 DEFAULT_CONFIDENCE_THRESHOLD = 0.65
 
 
+def _require(d: dict, key: str, where: str):
+    if not isinstance(d, dict) or key not in d:
+        raise ValueError(f"missing required field: {where}.{key}")
+    return d[key]
+
+
+def _validate_input(event: dict) -> tuple[dict, dict]:
+    if not isinstance(event, dict):
+        raise ValueError("event must be a JSON object")
+    fire_event = _require(event, "fire_event", "event")
+    recommendation = _require(event, "recommendation", "event")
+    _require(fire_event, "fire_id", "event.fire_event")
+    _require(recommendation, "confidence", "event.recommendation")
+    return fire_event, recommendation
+
+
+def _validate_advisory_shape(advisory) -> dict:
+    # Bedrock occasionally returns malformed JSON despite the prompt asking
+    # for a strict schema. Catch this BEFORE the audit row is written so
+    # we don't end up with an orphan prediction in the chain.
+    if not isinstance(advisory, dict) or "sms" not in advisory:
+        raise ValueError("advisory must be a dict with an 'sms' key")
+    return advisory
+
+
 def handler(event, context=None):
-    fire_event = event["fire_event"]
-    recommendation = event["recommendation"]
+    fire_event, recommendation = _validate_input(event)
     threshold = float(
         os.environ.get("WW_CONFIDENCE_THRESHOLD", DEFAULT_CONFIDENCE_THRESHOLD)
     )
 
-    advisory = generate_advisory(fire_event, recommendation)
+    advisory = _validate_advisory_shape(generate_advisory(fire_event, recommendation))
 
     prediction_id = log_prediction(fire_event["fire_id"], recommendation, advisory)
 
-    guardrail_result = validate_advisory(
-        advisory["sms"], confidence=recommendation["confidence"]
-    )
+    try:
+        guardrail_result = validate_advisory(
+            advisory["sms"], confidence=recommendation["confidence"]
+        )
+    except Exception as exc:
+        # Forensic record: the chain must show that validation was attempted
+        # and failed, otherwise the prediction row is an unexplained orphan.
+        append_guardrail_outcome(
+            fire_event["fire_id"],
+            prediction_id,
+            passed=False,
+            reason=f"guardrails service error: {type(exc).__name__}",
+        )
+        raise
 
     append_guardrail_outcome(
         fire_event["fire_id"],

--- a/tests/unit/test_safety_gate.py
+++ b/tests/unit/test_safety_gate.py
@@ -1,0 +1,187 @@
+"""Unit tests for the safety gate Lambda (#21).
+
+We mock the three collaborators (advisory generation, audit log, guardrails)
+because (a) advisory_prompt isn't merged to main yet (lives on ml-pipeline),
+and (b) the gate's job is orchestration - the integration test (#32) is
+where the real wiring gets exercised end-to-end.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, call
+
+import pytest
+
+
+# advisory_prompt lives on the ml-pipeline branch and isn't on main yet.
+# Inject a stub into sys.modules BEFORE importing the gate so the top-level
+# import in safety_gate.py resolves. Tests then patch the function via this
+# stub module (or directly on the safety_gate module's binding).
+@pytest.fixture(autouse=True)
+def stub_advisory_prompt():
+    # Don't touch the parent packages - they already resolve via the real
+    # ml/bedrock/ directory on disk (guardrails.py lives there). Just plant
+    # the missing submodule so the top-level import in safety_gate resolves.
+    stub = types.ModuleType("ml.bedrock.advisory_prompt")
+    stub.generate_advisory = MagicMock()
+    sys.modules["ml.bedrock.advisory_prompt"] = stub
+    yield stub
+    sys.modules.pop("ml.bedrock.advisory_prompt", None)
+
+
+@pytest.fixture
+def gate(stub_advisory_prompt, monkeypatch):
+    monkeypatch.setenv("WW_CONFIDENCE_THRESHOLD", "0.65")
+    # Reload to bind to the freshly-stubbed advisory_prompt module.
+    import importlib
+
+    from functions.alert import safety_gate
+
+    importlib.reload(safety_gate)
+    return safety_gate
+
+
+@pytest.fixture
+def mocks(gate, monkeypatch):
+    """Patch the three collaborators on the loaded gate module."""
+    fake_log = MagicMock(return_value="pred-123")
+    fake_outcome = MagicMock(return_value="outcome-456")
+    fake_validate = MagicMock(return_value={"passed": True, "blocked_reason": None})
+    fake_generate = MagicMock(return_value={"sms": "Evacuate east.", "brief": "Fire near Hwy 101."})
+
+    monkeypatch.setattr(gate, "log_prediction", fake_log)
+    monkeypatch.setattr(gate, "append_guardrail_outcome", fake_outcome)
+    monkeypatch.setattr(gate, "validate_advisory", fake_validate)
+    monkeypatch.setattr(gate, "generate_advisory", fake_generate)
+
+    return types.SimpleNamespace(
+        log=fake_log,
+        outcome=fake_outcome,
+        validate=fake_validate,
+        generate=fake_generate,
+    )
+
+
+def _event(confidence: float = 0.9) -> dict:
+    return {
+        "fire_event": {"fire_id": "fire-001", "lat": 34.2, "lon": -118.5},
+        "recommendation": {"recommendation": "dispatch 2 engines", "confidence": confidence},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path + routing
+# ---------------------------------------------------------------------------
+
+
+def test_high_confidence_passing_guardrails_returns_approved(gate, mocks):
+    resp = gate.handler(_event(confidence=0.9))
+    assert resp["action"] == "APPROVED"
+    assert resp["prediction_id"] == "pred-123"
+    assert resp["advisory"] == {"sms": "Evacuate east.", "brief": "Fire near Hwy 101."}
+
+
+def test_low_confidence_passing_guardrails_returns_human_review(gate, mocks):
+    resp = gate.handler(_event(confidence=0.4))
+    assert resp["action"] == "HUMAN_REVIEW_REQUIRED"
+    assert resp["prediction_id"] == "pred-123"
+    assert "advisory" in resp
+
+
+def test_failing_guardrails_returns_blocked_with_reason(gate, mocks):
+    mocks.validate.return_value = {
+        "passed": False,
+        "blocked_reason": "sensitiveInformationPolicy:PHONE(BLOCKED)",
+    }
+    resp = gate.handler(_event(confidence=0.9))
+    assert resp["action"] == "BLOCKED"
+    assert resp["blocked_reason"] == "sensitiveInformationPolicy:PHONE(BLOCKED)"
+    assert "advisory" not in resp  # don't expose blocked content downstream
+
+
+def test_blocked_takes_priority_over_low_confidence(gate, mocks):
+    # If guardrails block AND confidence is low, BLOCKED wins. There's no
+    # human review of unsafe content - the advisory itself is the problem.
+    mocks.validate.return_value = {"passed": False, "blocked_reason": "topicPolicy:X"}
+    resp = gate.handler(_event(confidence=0.3))
+    assert resp["action"] == "BLOCKED"
+
+
+def test_threshold_boundary_is_inclusive_at_high_end(gate, mocks):
+    # confidence == threshold counts as "high enough" - matches guardrails.py
+    resp = gate.handler(_event(confidence=0.65))
+    assert resp["action"] == "APPROVED"
+
+
+def test_threshold_overridable_via_env(gate, mocks, monkeypatch):
+    monkeypatch.setenv("WW_CONFIDENCE_THRESHOLD", "0.9")
+    resp = gate.handler(_event(confidence=0.8))
+    assert resp["action"] == "HUMAN_REVIEW_REQUIRED"
+
+
+# ---------------------------------------------------------------------------
+# Order-of-operations contract - the safety story depends on this
+# ---------------------------------------------------------------------------
+
+
+def test_log_prediction_called_before_validate(gate, mocks):
+    # The hard rule from CLAUDE.md: audit row before any safety-relevant
+    # downstream action. validate_advisory IS safety-relevant.
+    order = []
+    mocks.log.side_effect = lambda *a, **kw: order.append("log") or "pred-123"
+    mocks.validate.side_effect = lambda *a, **kw: order.append("validate") or {
+        "passed": True, "blocked_reason": None
+    }
+    mocks.outcome.side_effect = lambda *a, **kw: order.append("outcome") or "out-1"
+
+    gate.handler(_event(confidence=0.9))
+    assert order == ["log", "validate", "outcome"]
+
+
+def test_outcome_row_links_to_prediction_id(gate, mocks):
+    gate.handler(_event(confidence=0.9))
+    args, kwargs = mocks.outcome.call_args
+    assert args[0] == "fire-001"        # fire_id
+    assert args[1] == "pred-123"        # prediction_id (the link)
+    assert kwargs == {"passed": True, "reason": None}
+
+
+def test_outcome_row_written_even_when_blocked(gate, mocks):
+    # The audit chain captures blocked outcomes too - that's the whole point
+    # of an audit log: blocked attempts are evidence, not noise.
+    mocks.validate.return_value = {"passed": False, "blocked_reason": "PII"}
+    gate.handler(_event(confidence=0.9))
+    mocks.outcome.assert_called_once()
+    _, kwargs = mocks.outcome.call_args
+    assert kwargs == {"passed": False, "reason": "PII"}
+
+
+# ---------------------------------------------------------------------------
+# Failure semantics - what gets called (or not) on collaborator failure
+# ---------------------------------------------------------------------------
+
+
+def test_advisory_generation_failure_writes_no_audit_row(gate, mocks):
+    mocks.generate.side_effect = RuntimeError("Bedrock 5xx")
+    with pytest.raises(RuntimeError, match="Bedrock 5xx"):
+        gate.handler(_event(confidence=0.9))
+    mocks.log.assert_not_called()
+    mocks.validate.assert_not_called()
+    mocks.outcome.assert_not_called()
+
+
+def test_log_prediction_failure_halts_before_guardrails(gate, mocks):
+    # Hard rule: never proceed past the audit write. If it raises, halt -
+    # the system's safety story depends on the audit row being committed.
+    mocks.log.side_effect = RuntimeError("DynamoDB throttled")
+    with pytest.raises(RuntimeError, match="DynamoDB throttled"):
+        gate.handler(_event(confidence=0.9))
+    mocks.validate.assert_not_called()
+    mocks.outcome.assert_not_called()
+
+
+def test_guardrails_validation_called_with_sms_and_confidence(gate, mocks):
+    # Must pass the SMS text (the actual delivery payload) and the model
+    # confidence (so guardrails' in-process certainty check can run).
+    gate.handler(_event(confidence=0.42))
+    mocks.validate.assert_called_once_with("Evacuate east.", confidence=0.42)

--- a/tests/unit/test_safety_gate.py
+++ b/tests/unit/test_safety_gate.py
@@ -124,10 +124,13 @@ def test_threshold_overridable_via_env(gate, mocks, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_log_prediction_called_before_validate(gate, mocks):
-    # The hard rule from CLAUDE.md: audit row before any safety-relevant
-    # downstream action. validate_advisory IS safety-relevant.
+def test_strict_call_order(gate, mocks):
+    # Full chain: generate FIRST (otherwise we'd audit empty data),
+    # then log, then validate, then outcome. Reordering breaks #32.
     order = []
+    mocks.generate.side_effect = lambda *a, **kw: order.append("generate") or {
+        "sms": "Evacuate east.", "brief": "b"
+    }
     mocks.log.side_effect = lambda *a, **kw: order.append("log") or "pred-123"
     mocks.validate.side_effect = lambda *a, **kw: order.append("validate") or {
         "passed": True, "blocked_reason": None
@@ -135,7 +138,7 @@ def test_log_prediction_called_before_validate(gate, mocks):
     mocks.outcome.side_effect = lambda *a, **kw: order.append("outcome") or "out-1"
 
     gate.handler(_event(confidence=0.9))
-    assert order == ["log", "validate", "outcome"]
+    assert order == ["generate", "log", "validate", "outcome"]
 
 
 def test_outcome_row_links_to_prediction_id(gate, mocks):
@@ -185,3 +188,77 @@ def test_guardrails_validation_called_with_sms_and_confidence(gate, mocks):
     # confidence (so guardrails' in-process certainty check can run).
     gate.handler(_event(confidence=0.42))
     mocks.validate.assert_called_once_with("Evacuate east.", confidence=0.42)
+
+
+# ---------------------------------------------------------------------------
+# Forensic completeness - the audit chain must explain what happened
+# ---------------------------------------------------------------------------
+
+
+def test_validate_advisory_failure_writes_error_outcome_then_raises(gate, mocks):
+    # Bedrock outage during validation. Without a forensic outcome row, the
+    # audit chain has an unexplained orphan prediction; Step Functions retries
+    # would pile up more orphans. We append an outcome row before re-raising.
+    mocks.validate.side_effect = RuntimeError("Bedrock 503")
+    with pytest.raises(RuntimeError, match="Bedrock 503"):
+        gate.handler(_event(confidence=0.9))
+
+    mocks.log.assert_called_once()
+    mocks.outcome.assert_called_once()
+    args, kwargs = mocks.outcome.call_args
+    assert args == ("fire-001", "pred-123")
+    assert kwargs["passed"] is False
+    assert "guardrails service error" in kwargs["reason"]
+    assert "RuntimeError" in kwargs["reason"]
+
+
+def test_outcome_row_failure_propagates(gate, mocks):
+    # Rare but possible (DynamoDB throttle). Propagation is correct because
+    # the Lambda has no clean way to roll back the prediction row.
+    mocks.outcome.side_effect = RuntimeError("DDB throttle")
+    with pytest.raises(RuntimeError, match="DDB throttle"):
+        gate.handler(_event(confidence=0.9))
+
+
+# ---------------------------------------------------------------------------
+# Input validation - structured errors instead of opaque KeyErrors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("event,missing", [
+    ({}, "fire_event"),
+    ({"recommendation": {"confidence": 0.9}}, "fire_event"),
+    ({"fire_event": {"fire_id": "f1"}}, "recommendation"),
+    ({"fire_event": {}, "recommendation": {"confidence": 0.9}}, "fire_id"),
+    ({"fire_event": {"fire_id": "f1"}, "recommendation": {}}, "confidence"),
+])
+def test_missing_required_fields_raise_value_error(gate, mocks, event, missing):
+    with pytest.raises(ValueError, match=missing):
+        gate.handler(event)
+    mocks.generate.assert_not_called()
+    mocks.log.assert_not_called()
+
+
+def test_non_dict_event_raises_value_error(gate, mocks):
+    for bad in [None, "string", 42, [1, 2]]:
+        with pytest.raises(ValueError, match="JSON object"):
+            gate.handler(bad)
+
+
+def test_malformed_advisory_raises_before_audit_row(gate, mocks):
+    # If Bedrock returns a string instead of {"sms": ..., "brief": ...},
+    # we must catch it BEFORE writing the prediction row - otherwise the
+    # chain has an orphan with no recoverable advisory text.
+    mocks.generate.return_value = "not a dict"
+    with pytest.raises(ValueError, match="sms"):
+        gate.handler(_event(confidence=0.9))
+    mocks.log.assert_not_called()
+    mocks.outcome.assert_not_called()
+
+
+def test_advisory_dict_missing_sms_raises_before_audit_row(gate, mocks):
+    mocks.generate.return_value = {"brief": "no sms here"}
+    with pytest.raises(ValueError, match="sms"):
+        gate.handler(_event(confidence=0.9))
+    mocks.log.assert_not_called()
+    mocks.outcome.assert_not_called()


### PR DESCRIPTION
## Summary
The single choke point Lambda every advisory passes through before the alert sender (#22). Composes the work from #14 (Bedrock advisory), #16 (Guardrails wrapper), and #17 (audit hash-chain) into the contract from `CLAUDE.md` and `.claude/skills/ai-safety/SKILL.md`.

Order of operations is non-negotiable - reorder these and the safety contract test (#32) will fail:
1. `generate_advisory` (Bedrock)
2. `log_prediction` - audit row committed **before** guardrails
3. `validate_advisory` (Guardrails)
4. `append_guardrail_outcome` - new row, never mutate the prior
5. confidence threshold check

## Three return actions
| Action | When |
|---|---|
| `APPROVED` | guardrails pass + confidence >= threshold |
| `HUMAN_REVIEW_REQUIRED` | guardrails pass + confidence < threshold (advisory is safe, just uncertain) |
| `BLOCKED` | guardrails fail (advisory itself is unsafe; no human override) |

`BLOCKED` takes priority over `HUMAN_REVIEW_REQUIRED` - there's no human review of unsafe content.

## Failure semantics
- Bedrock generation raises -> no audit row written (nothing safety-relevant happened yet)
- `log_prediction` raises -> halt before guardrails call (audit contract requires row be committed first)

## Dependency note
This Lambda imports `ml.bedrock.advisory_prompt.generate_advisory` from #14, which currently lives on `origin/ml-pipeline` and hasn't been merged to main. Tests stub the import via `sys.modules`, so this PR's test suite passes independently. **Deploy will fail until ml-pipeline merges.**

## Test plan
- [x] 12 unit tests in `tests/unit/test_safety_gate.py`, all passing
  - Routing: APPROVED / HUMAN_REVIEW_REQUIRED / BLOCKED, blocked-priority-over-low-confidence, threshold inclusive at high end, env-var override
  - Order: `log_prediction` strictly before `validate_advisory` (verified via call ordering)
  - Linkage: outcome row's `linked_prediction_id` matches the prediction
  - Failure: advisory generation failure writes no audit row; log_prediction failure skips guardrails
  - Wiring: `validate_advisory` receives the SMS text and confidence
- [x] Full unit suite (61 tests) passes

## Closes
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)