### PR TITLE
docs: check GitHub for existing claims before /claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ A real-time wildfire resource dispatch and community alert system. Two hackathon
 ## Issue workflow
 
 1. Check `docs/ISSUES.md` for dependencies before starting anything
-2. Run `/claim N` to assign yourself and verify deps are clear-- make sure the issue is not already claimed
+2. Run `/claim N` to assign yourself and verify deps are clear-- make sure the issue is not already claimed either on the md or ON GITHUB
 3. Work the issue using the relevant agent in `.claude/agents/`
 4. Read the relevant SKILL.md in `.claude/skills/` before writing code
 5. Commit with `[#N]` in the message


### PR DESCRIPTION
## Summary
- Updates the issue workflow in CLAUDE.md to also check GitHub (not just docs/ISSUES.md) for existing claims before running `/claim`.

## Test plan
- [x] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)