### PR TITLE
[#12] Train SageMaker XGBoost dispatch model

### DIFF
--- a/ml/dispatch_model/features.py
+++ b/ml/dispatch_model/features.py
@@ -1,0 +1,72 @@
+"""
+Feature engineering for the dispatch recommendation model.
+
+The feature vector is a fixed-length list of numbers. Every column must appear
+in the same order here, in the training CSV, and at inference time — if the
+order drifts between training and serving, the model silently produces wrong
+predictions with no error.
+
+FEATURE_NAMES is the single source of truth for that order.
+"""
+
+# Dispatch level labels — used in training data generation and prediction output.
+DISPATCH_LEVELS = {
+    0: "LOCAL",       # local units only
+    1: "MUTUAL_AID",  # call neighboring departments
+    2: "AERIAL",      # aerial support + mutual aid
+}
+
+# Ordered feature names — must match the column order in train.csv exactly.
+FEATURE_NAMES = [
+    "lat",                    # fire latitude (geographic signal — terrain, urban density)
+    "lon",                    # fire longitude
+    "spread_rate_km2_per_hr", # how fast the fire is growing — biggest dispatch driver
+    "population_at_risk",     # people within the risk radius (from census enrichment)
+    "nearest_station_dist_km",# distance to closest available fire station
+    "wind_speed_ms",          # wind accelerates spread dramatically
+    "radiative_power",        # satellite-measured fire intensity (MW)
+    "hour_of_day",            # night fires are harder to fight (visibility, crew fatigue)
+    "is_weekend",             # staffing is thinner on weekends
+]
+
+
+def extract_features(fire_event: dict) -> list:
+    """Pull the feature vector from a normalized + enriched fire event dict.
+
+    The enriched schema adds risk_score, wind fields, population_at_risk, and
+    nearest_stations. This function is used at inference time (inside the Lambda
+    that calls the SageMaker endpoint) so the same logic runs in prod as in training.
+
+    Args:
+        fire_event: enriched fire event following the schema in CLAUDE.md
+
+    Returns:
+        list of floats in FEATURE_NAMES order
+    """
+    from datetime import datetime
+
+    detected_at = fire_event.get("detected_at", "")
+    try:
+        dt = datetime.fromisoformat(detected_at.replace("Z", "+00:00"))
+        hour_of_day = dt.hour
+        is_weekend = 1 if dt.weekday() >= 5 else 0
+    except (ValueError, AttributeError):
+        # If timestamp is malformed, default to noon weekday (neutral values).
+        hour_of_day = 12
+        is_weekend = 0
+
+    # nearest_stations is a list sorted by distance — take the closest available one.
+    stations = fire_event.get("nearest_stations", [])
+    nearest_dist = stations[0]["distance_km"] if stations else 50.0  # assume far if unknown
+
+    return [
+        float(fire_event.get("lat", 0.0)),
+        float(fire_event.get("lon", 0.0)),
+        float(fire_event.get("spread_rate_km2_per_hr", 0.0)),
+        float(fire_event.get("population_at_risk", 0)),
+        float(nearest_dist),
+        float(fire_event.get("wind_speed_ms", 0.0)),
+        float(fire_event.get("radiative_power", 0.0)),
+        float(hour_of_day),
+        float(is_weekend),
+    ]

--- a/ml/dispatch_model/model.py
+++ b/ml/dispatch_model/model.py
@@ -1,0 +1,82 @@
+"""
+XGBoost dispatch recommendation model — build, save, load, predict.
+
+Keeping this separate from train.py means the inference Lambda (#13) can import
+load_model and predict without pulling in any training dependencies.
+"""
+
+import os
+import json
+import xgboost as xgb
+from features import DISPATCH_LEVELS, FEATURE_NAMES
+
+
+def build_model(max_depth: int = 6, n_estimators: int = 150, learning_rate: float = 0.1):
+    """Return an untrained XGBClassifier with the given hyperparameters.
+
+    XGBoost is a gradient-boosted decision tree ensemble. It builds trees
+    sequentially where each new tree corrects the errors of the previous ones.
+    predict_proba gives us per-class probabilities — that's where the
+    confidence score (max probability) comes from.
+    """
+    return xgb.XGBClassifier(
+        max_depth=max_depth,
+        n_estimators=n_estimators,
+        learning_rate=learning_rate,
+        num_class=len(DISPATCH_LEVELS),   # 3 dispatch levels
+        objective="multi:softprob",        # output full probability distribution, not just winner
+        eval_metric="mlogloss",            # multi-class log loss for evaluation
+        random_state=42,
+    )
+
+
+def save_model(model: xgb.XGBClassifier, model_dir: str):
+    """Save model to model_dir/model.xgb — SageMaker tars this directory into model.tar.gz."""
+    os.makedirs(model_dir, exist_ok=True)
+    model_path = os.path.join(model_dir, "model.xgb")
+    model.save_model(model_path)
+
+    # Save feature names alongside the model so the endpoint can validate input order.
+    meta_path = os.path.join(model_dir, "feature_meta.json")
+    with open(meta_path, "w") as f:
+        json.dump({"feature_names": FEATURE_NAMES, "dispatch_levels": DISPATCH_LEVELS}, f)
+
+    return model_path
+
+
+def load_model(model_dir: str) -> xgb.XGBClassifier:
+    """Load model from model_dir — called by the SageMaker endpoint container at startup."""
+    model = xgb.XGBClassifier()
+    model.load_model(os.path.join(model_dir, "model.xgb"))
+    return model
+
+
+def predict(model: xgb.XGBClassifier, features: list) -> dict:
+    """Run inference and return recommendation + confidence.
+
+    Args:
+        features: list of floats in FEATURE_NAMES order (use features.extract_features)
+
+    Returns:
+        dict with:
+          dispatch_level (int 0-2)
+          recommendation (str "LOCAL" | "MUTUAL_AID" | "AERIAL")
+          confidence (float 0-1) — probability of the winning class
+          probabilities (dict) — full class probability breakdown
+    """
+    import numpy as np
+
+    # XGBoost expects a 2D array — one row per sample.
+    X = np.array([features])
+    probs = model.predict_proba(X)[0]   # shape (3,) — one prob per dispatch level
+
+    dispatch_level = int(np.argmax(probs))
+    confidence = float(probs[dispatch_level])
+
+    return {
+        "dispatch_level": dispatch_level,
+        "recommendation": DISPATCH_LEVELS[dispatch_level],
+        "confidence": confidence,
+        # Full breakdown for transparency in the dispatch panel (#28).
+        "probabilities": {DISPATCH_LEVELS[i]: float(p) for i, p in enumerate(probs)},
+    }

--- a/ml/dispatch_model/requirements.txt
+++ b/ml/dispatch_model/requirements.txt
@@ -1,0 +1,5 @@
+xgboost==1.7.6
+scikit-learn==1.3.2
+pandas==2.1.4
+numpy==1.26.4
+boto3>=1.34.0

--- a/ml/dispatch_model/train.py
+++ b/ml/dispatch_model/train.py
@@ -1,0 +1,186 @@
+"""
+SageMaker training entry point for the wildfire dispatch recommendation model.
+
+SageMaker runs this script inside a managed container. It passes:
+  - Hyperparameters as CLI flags (--max-depth, etc.)
+  - The training data path via SM_CHANNEL_TRAIN env var
+  - The output model path via SM_MODEL_DIR env var
+
+After training, SageMaker tars SM_MODEL_DIR into model.tar.gz and stores it
+in S3. Issue #13 then deploys that artifact as an endpoint.
+
+Run locally (for testing without SageMaker):
+  python train.py --local --train-path ml/data/train.csv --model-dir /tmp/model
+"""
+
+import argparse
+import json
+import os
+import sys
+import boto3
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report, accuracy_score
+
+# SageMaker injects the training script's directory into sys.path so we can
+# import sibling modules (features.py, model.py) without a package install.
+sys.path.insert(0, os.path.dirname(__file__))
+from features import FEATURE_NAMES
+from model import build_model, save_model
+
+
+def load_data(train_path: str) -> tuple:
+    """Load training CSV and split into features (X) and labels (y)."""
+    csv_path = os.path.join(train_path, "train.csv")
+    df = pd.read_csv(csv_path)
+
+    # Validate that the CSV has all expected columns — catches data drift early.
+    missing = set(FEATURE_NAMES) - set(df.columns)
+    if missing:
+        raise ValueError(f"Training data missing columns: {missing}")
+
+    X = df[FEATURE_NAMES].values.astype(np.float32)
+    y = df["label"].values.astype(int)
+    return X, y
+
+
+def evaluate(model, X_val, y_val) -> dict:
+    """Return accuracy and per-class metrics — logged to CloudWatch by SageMaker."""
+    y_pred = model.predict(X_val)
+    acc = accuracy_score(y_val, y_pred)
+    report = classification_report(
+        y_val, y_pred,
+        target_names=["LOCAL", "MUTUAL_AID", "AERIAL"],
+        output_dict=True,
+    )
+    print(f"\nValidation accuracy: {acc:.4f}")
+    print(classification_report(y_val, y_pred, target_names=["LOCAL", "MUTUAL_AID", "AERIAL"]))
+    return {"accuracy": acc, "classification_report": report}
+
+
+def register_model(model_s3_uri: str, metrics: dict, model_package_group: str):
+    """Register the trained model in SageMaker Model Registry.
+
+    Model Registry lets us version, compare, and approve models before deploying.
+    Issue #13 reads the latest "Approved" version from this group and deploys it.
+    """
+    sm = boto3.client("sagemaker")
+
+    # The inference spec tells SageMaker which container to use for serving.
+    # We use the AWS-managed XGBoost container so we don't need a custom image.
+    inference_spec = {
+        "Containers": [
+            {
+                "Image": _xgboost_inference_image(),
+                "ModelDataUrl": model_s3_uri,
+                "Framework": "XGBOOST",
+                "FrameworkVersion": "1.7-1",
+            }
+        ],
+        "SupportedContentTypes": ["application/json"],
+        "SupportedResponseMIMETypes": ["application/json"],
+        "SupportedTransformInstanceTypes": ["ml.m5.large"],
+        "SupportedRealtimeInferenceInstanceTypes": ["ml.m5.large"],
+    }
+
+    response = sm.create_model_package(
+        ModelPackageGroupName=model_package_group,
+        ModelPackageDescription=f"XGBoost dispatch model — accuracy {metrics['accuracy']:.4f}",
+        InferenceSpecification=inference_spec,
+        ModelApprovalStatus="PendingManualApproval",  # issue #13 approves + deploys
+        ModelMetrics={
+            "ModelQuality": {
+                "Statistics": {
+                    "ContentType": "application/json",
+                    "S3Uri": "",  # populated by Clarify in issue #18
+                }
+            }
+        },
+        CustomerMetadataProperties={
+            "accuracy": str(round(metrics["accuracy"], 4)),
+            "local_f1": str(round(metrics["classification_report"]["LOCAL"]["f1-score"], 4)),
+            "mutual_aid_f1": str(round(metrics["classification_report"]["MUTUAL_AID"]["f1-score"], 4)),
+            "aerial_f1": str(round(metrics["classification_report"]["AERIAL"]["f1-score"], 4)),
+        },
+    )
+    arn = response["ModelPackageArn"]
+    print(f"\nRegistered model package: {arn}")
+    return arn
+
+
+def _xgboost_inference_image() -> str:
+    """Return the AWS-managed XGBoost 1.7-1 container URI for us-west-2."""
+    # ECR image URIs are region-specific. Hardcoding us-west-2 to match the project region.
+    # If you change region in cdk.json, update this too.
+    return "246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.7-1"
+
+
+def train(args):
+    print(f"Loading data from {args.train_path} ...")
+    X, y = load_data(args.train_path)
+
+    # 80/20 train-validation split — stratified so all dispatch levels are
+    # represented in both splits even if the dataset is class-imbalanced.
+    X_train, X_val, y_train, y_val = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y
+    )
+    print(f"Train: {len(X_train)} samples | Val: {len(X_val)} samples")
+
+    print(f"\nTraining XGBoost (max_depth={args.max_depth}, n_estimators={args.n_estimators}) ...")
+    model = build_model(
+        max_depth=args.max_depth,
+        n_estimators=args.n_estimators,
+        learning_rate=args.learning_rate,
+    )
+    # eval_set lets XGBoost print validation loss each round — useful for spotting overfitting.
+    model.fit(
+        X_train, y_train,
+        eval_set=[(X_val, y_val)],
+        verbose=25,  # print every 25 rounds
+    )
+
+    metrics = evaluate(model, X_val, y_val)
+
+    model_path = save_model(model, args.model_dir)
+    print(f"\nModel saved → {model_path}")
+
+    # Register in Model Registry unless running locally (no SageMaker context).
+    if not args.local and args.model_package_group:
+        # SageMaker stores the artifact at a known S3 path after training completes.
+        bucket = os.environ.get("WW_ML_BUCKET", "wildfire-watch-ml-data")
+        model_s3_uri = f"s3://{bucket}/models/{os.environ.get('TRAINING_JOB_NAME', 'local')}/output/model.tar.gz"
+        register_model(model_s3_uri, metrics, args.model_package_group)
+
+    return metrics
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    # SageMaker hyperparameter arguments — passed via the Estimator in issue #12 CDK/notebook.
+    parser.add_argument("--max-depth", type=int, default=6,
+                        help="XGBoost max tree depth (higher = more complex, risk of overfitting)")
+    parser.add_argument("--n-estimators", type=int, default=150,
+                        help="Number of boosting rounds")
+    parser.add_argument("--learning-rate", type=float, default=0.1,
+                        help="Step size shrinkage — lower = slower but more robust")
+
+    # SageMaker injects SM_CHANNEL_TRAIN and SM_MODEL_DIR automatically.
+    # We default to those env vars so the script works without flags in the container.
+    parser.add_argument("--train-path", type=str,
+                        default=os.environ.get("SM_CHANNEL_TRAIN", "ml/data"),
+                        help="Directory containing train.csv")
+    parser.add_argument("--model-dir", type=str,
+                        default=os.environ.get("SM_MODEL_DIR", "/tmp/model"),
+                        help="Directory to write model artifact")
+    parser.add_argument("--model-package-group", type=str,
+                        default=os.environ.get("WW_MODEL_PACKAGE_GROUP", "wildfire-watch-dispatch"),
+                        help="SageMaker Model Registry group to register into")
+
+    # Local mode skips S3 upload and Model Registry — useful for fast iteration.
+    parser.add_argument("--local", action="store_true",
+                        help="Run locally without SageMaker context")
+
+    args = parser.parse_args()
+    train(args)

--- a/ml/scripts/generate_training_data.py
+++ b/ml/scripts/generate_training_data.py
@@ -1,0 +1,122 @@
+"""
+Generate synthetic fire dispatch training data and upload it to S3.
+
+Real sources (USFS Fire Occurrence Database, CAL FIRE historical) require
+multi-GB downloads and data-access agreements. For the hackathon we generate
+realistic synthetic data using domain-informed heuristics, then add Gaussian
+noise so the model has variance to learn from rather than memorizing rules.
+
+Label heuristic (informed by CAL FIRE dispatch protocols):
+  - spread_rate > 3.0 km²/hr  OR  (population > 800 AND wind > 8 m/s) → AERIAL (2)
+  - spread_rate > 1.2 km²/hr  OR  population > 250                    → MUTUAL_AID (1)
+  - else                                                                → LOCAL (0)
+
+~15% noise is added to simulate edge cases, ambiguous dispatches, and data
+entry errors in historical records.
+"""
+
+import argparse
+import os
+import random
+import numpy as np
+import pandas as pd
+import boto3
+
+# Bounding box for Southern California — where CAL FIRE incidents concentrate.
+LAT_RANGE = (33.5, 34.8)
+LON_RANGE = (-118.8, -116.5)
+
+RANDOM_SEED = 42
+
+
+def _label(spread_rate, population, wind_speed):
+    """Deterministic dispatch label from domain heuristics."""
+    if spread_rate > 3.0 or (population > 800 and wind_speed > 8.0):
+        return 2  # AERIAL
+    if spread_rate > 1.2 or population > 250:
+        return 1  # MUTUAL_AID
+    return 0      # LOCAL
+
+
+def generate(n_samples: int, noise_rate: float = 0.15) -> pd.DataFrame:
+    """Return a DataFrame of n_samples synthetic fire dispatch records."""
+    rng = np.random.RandomState(RANDOM_SEED)
+    random.seed(RANDOM_SEED)
+
+    rows = []
+    for _ in range(n_samples):
+        # Sample fire characteristics from realistic distributions.
+        lat = rng.uniform(*LAT_RANGE)
+        lon = rng.uniform(*LON_RANGE)
+        spread_rate = rng.exponential(scale=1.5)             # most fires spread slowly
+        population = int(rng.lognormal(mean=5.0, sigma=1.2)) # log-normal: few dense areas
+        nearest_dist = rng.uniform(2.0, 45.0)               # km to nearest station
+        wind_speed = rng.weibull(a=2.0) * 6.0               # Weibull matches wind data
+        radiative_power = rng.exponential(scale=300.0)       # MW, heavy-tailed
+        hour_of_day = rng.randint(0, 24)
+        is_weekend = int(rng.random() < 0.286)               # 2/7 days are weekends
+
+        label = _label(spread_rate, population, wind_speed)
+
+        # Inject noise to simulate real-world label ambiguity.
+        if rng.random() < noise_rate:
+            label = rng.randint(0, 3)
+
+        rows.append({
+            "lat": round(lat, 6),
+            "lon": round(lon, 6),
+            "spread_rate_km2_per_hr": round(spread_rate, 3),
+            "population_at_risk": population,
+            "nearest_station_dist_km": round(nearest_dist, 2),
+            "wind_speed_ms": round(wind_speed, 2),
+            "radiative_power": round(radiative_power, 1),
+            "hour_of_day": hour_of_day,
+            "is_weekend": is_weekend,
+            "label": label,
+        })
+
+    df = pd.DataFrame(rows)
+
+    # Log class distribution so we can spot severe imbalance before training.
+    counts = df["label"].value_counts().sort_index()
+    print(f"Generated {n_samples} samples — label distribution:")
+    for lvl, name in {0: "LOCAL", 1: "MUTUAL_AID", 2: "AERIAL"}.items():
+        print(f"  {name}: {counts.get(lvl, 0)} ({counts.get(lvl, 0)/n_samples*100:.1f}%)")
+
+    return df
+
+
+def upload_to_s3(df: pd.DataFrame, bucket: str, prefix: str = "training"):
+    """Write CSV locally then upload to S3 for SageMaker to consume."""
+    local_path = "/tmp/train.csv"
+    df.to_csv(local_path, index=False)
+
+    s3 = boto3.client("s3")
+    s3_key = f"{prefix}/train.csv"
+    s3.upload_file(local_path, bucket, s3_key)
+    s3_uri = f"s3://{bucket}/{s3_key}"
+    print(f"Uploaded training data → {s3_uri}")
+    return s3_uri
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate synthetic dispatch training data")
+    parser.add_argument("--n-samples", type=int, default=10_000,
+                        help="Number of synthetic fire records to generate")
+    parser.add_argument("--bucket", type=str,
+                        default=os.environ.get("WW_ML_BUCKET", "wildfire-watch-ml-data"),
+                        help="S3 bucket to upload training CSV")
+    parser.add_argument("--local-only", action="store_true",
+                        help="Save CSV locally and skip S3 upload (for testing)")
+    parser.add_argument("--output-path", type=str, default="ml/data/train.csv",
+                        help="Local output path when --local-only is set")
+    args = parser.parse_args()
+
+    df = generate(args.n_samples)
+
+    if args.local_only:
+        os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
+        df.to_csv(args.output_path, index=False)
+        print(f"Saved locally → {args.output_path}")
+    else:
+        upload_to_s3(df, args.bucket)


### PR DESCRIPTION
## Summary
- `ml/dispatch_model/features.py` — canonical feature list (9 features), `DISPATCH_LEVELS` enum, `extract_features()` for normalizing fire event dicts
- `ml/dispatch_model/model.py` — XGBClassifier with `multi:softprob`, save/load/predict helpers returning confidence + probabilities
- `ml/dispatch_model/train.py` — SageMaker training script with argparse, Model Registry registration, `--local` flag for offline dev
- `ml/scripts/generate_training_data.py` — 10k synthetic SoCal fire scenarios with realistic spread/population/wind distributions

## Test plan
- [ ] `python ml/scripts/generate_training_data.py --local-only` writes `ml/data/train.csv`
- [ ] `python ml/dispatch_model/train.py --local --train-path ml/data/train.csv` trains and saves model locally

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)