### PR TITLE
[#26] Fire perimeter overlay with live CAL FIRE data + mock toggle

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,5 @@
 VITE_MAPBOX_TOKEN=pk.your_mapbox_public_token_here
+
+# Set to "true" to render demo polygons from public/data/active_fires.geojson
+# instead of fetching live incidents from CAL FIRE. Use for the demo run.
+VITE_USE_MOCK_FIRES=false

--- a/frontend/public/data/active_fires.geojson
+++ b/frontend/public/data/active_fires.geojson
@@ -1,0 +1,235 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "fire_id": "demo-thousand-oaks",
+        "name": "Thousand Oaks Fire",
+        "containment_pct": 15,
+        "spread_rate_km2_per_hr": 2.1,
+        "detected_at": "2026-04-18T14:00:00Z",
+        "last_updated": "2026-04-18T20:13:34.028940Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -118.85,
+              34.18
+            ],
+            [
+              -118.82,
+              34.19
+            ],
+            [
+              -118.81,
+              34.17
+            ],
+            [
+              -118.82,
+              34.15
+            ],
+            [
+              -118.85,
+              34.15
+            ],
+            [
+              -118.86,
+              34.17
+            ],
+            [
+              -118.85,
+              34.18
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fire_id": "demo-malibu",
+        "name": "Malibu Coastal Fire",
+        "containment_pct": 35,
+        "spread_rate_km2_per_hr": 3.4,
+        "detected_at": "2026-04-18T11:30:00Z",
+        "last_updated": "2026-04-18T20:13:34.028940Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -118.8,
+              34.04
+            ],
+            [
+              -118.76,
+              34.05
+            ],
+            [
+              -118.74,
+              34.03
+            ],
+            [
+              -118.75,
+              34.01
+            ],
+            [
+              -118.79,
+              34.0
+            ],
+            [
+              -118.81,
+              34.02
+            ],
+            [
+              -118.8,
+              34.04
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fire_id": "demo-big-bear",
+        "name": "Big Bear Ridge Fire",
+        "containment_pct": 65,
+        "spread_rate_km2_per_hr": 0.8,
+        "detected_at": "2026-04-17T22:15:00Z",
+        "last_updated": "2026-04-18T20:13:34.028940Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -116.94,
+              34.27
+            ],
+            [
+              -116.9,
+              34.28
+            ],
+            [
+              -116.88,
+              34.26
+            ],
+            [
+              -116.89,
+              34.24
+            ],
+            [
+              -116.93,
+              34.23
+            ],
+            [
+              -116.95,
+              34.25
+            ],
+            [
+              -116.94,
+              34.27
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fire_id": "demo-inland-empire",
+        "name": "Inland Empire Industrial",
+        "containment_pct": 5,
+        "spread_rate_km2_per_hr": 4.2,
+        "detected_at": "2026-04-18T16:45:00Z",
+        "last_updated": "2026-04-18T20:13:34.028940Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -117.32,
+              34.06
+            ],
+            [
+              -117.27,
+              34.07
+            ],
+            [
+              -117.25,
+              34.05
+            ],
+            [
+              -117.26,
+              34.02
+            ],
+            [
+              -117.3,
+              34.01
+            ],
+            [
+              -117.33,
+              34.03
+            ],
+            [
+              -117.32,
+              34.06
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fire_id": "demo-shasta",
+        "name": "Shasta Trinity Fire",
+        "containment_pct": 88,
+        "spread_rate_km2_per_hr": 0.2,
+        "detected_at": "2026-04-16T09:00:00Z",
+        "last_updated": "2026-04-18T20:13:34.028940Z"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -122.42,
+              40.61
+            ],
+            [
+              -122.36,
+              40.62
+            ],
+            [
+              -122.34,
+              40.59
+            ],
+            [
+              -122.36,
+              40.56
+            ],
+            [
+              -122.41,
+              40.56
+            ],
+            [
+              -122.43,
+              40.58
+            ],
+            [
+              -122.42,
+              40.61
+            ]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -1,15 +1,128 @@
 import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { useEffect, useRef, useState } from 'react'
+import { fetchActiveFires } from './api/fires'
 
 mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN
 
 const STATIONS_URL = '/data/fire_stations.geojson'
+const FIRE_REFRESH_MS = 30_000
+
+function formatRelative(iso) {
+  if (!iso) return 'unknown'
+  const diffMs = Date.now() - new Date(iso).getTime()
+  if (diffMs < 0) return 'just now'
+  const mins = Math.floor(diffMs / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+const STYLES = {
+  light: 'mapbox://styles/mapbox/light-v11',
+  dark: 'mapbox://styles/mapbox/dark-v11',
+}
 
 export default function FireMap() {
   const containerRef = useRef(null)
   const mapRef = useRef(null)
+  const stationsRef = useRef(null)
+  const firesRef = useRef(null)
+  const didInitTheme = useRef(false)
   const [error, setError] = useState(null)
+  const [theme, setTheme] = useState('light')
+
+  // Adds the stations source + circle layer. Called on first load and after
+  // every setStyle() — changing the basemap wipes user-added sources/layers.
+  const addStationsLayer = (map, data) => {
+    if (map.getLayer('fire-stations-circle')) map.removeLayer('fire-stations-circle')
+    if (map.getSource('fire-stations')) map.removeSource('fire-stations')
+
+    map.addSource('fire-stations', { type: 'geojson', data })
+    map.addLayer({
+      id: 'fire-stations-circle',
+      type: 'circle',
+      source: 'fire-stations',
+      paint: {
+        'circle-radius': 7,
+        'circle-color': [
+          'case',
+          ['==', ['get', 'available'], true], '#22cc44',
+          '#ff3322',
+        ],
+        'circle-stroke-width': 1.5,
+        'circle-stroke-color': '#ffffff',
+      },
+    })
+  }
+
+  // Fire perimeter fill + outline (for polygons) and circle (for points).
+  // CAL FIRE live data is point-only; mock demo data is polygons. One source,
+  // two layer types filtered by geometry. Color interpolates by containment.
+  const addFiresLayer = (map, data) => {
+    for (const id of ['fires-fill', 'fires-outline', 'fires-circle']) {
+      if (map.getLayer(id)) map.removeLayer(id)
+    }
+    if (map.getSource('active-fires')) map.removeSource('active-fires')
+
+    const containmentColor = [
+      'interpolate', ['linear'], ['get', 'containment_pct'],
+      0,   '#ff2200',
+      25,  '#ff6600',
+      50,  '#ffaa00',
+      75,  '#ffdd33',
+      100, '#22cc44',
+    ]
+
+    map.addSource('active-fires', { type: 'geojson', data })
+    map.addLayer({
+      id: 'fires-fill',
+      type: 'fill',
+      source: 'active-fires',
+      filter: ['==', ['geometry-type'], 'Polygon'],
+      paint: { 'fill-color': containmentColor, 'fill-opacity': 0.55 },
+    }, 'fire-stations-circle')
+    map.addLayer({
+      id: 'fires-outline',
+      type: 'line',
+      source: 'active-fires',
+      filter: ['==', ['geometry-type'], 'Polygon'],
+      paint: { 'line-color': '#000', 'line-width': 1.2, 'line-opacity': 0.4 },
+    }, 'fire-stations-circle')
+    map.addLayer({
+      id: 'fires-circle',
+      type: 'circle',
+      source: 'active-fires',
+      filter: ['==', ['geometry-type'], 'Point'],
+      paint: {
+        'circle-radius': [
+          'interpolate', ['linear'], ['zoom'],
+          5, 6,
+          10, 14,
+        ],
+        'circle-color': containmentColor,
+        'circle-opacity': 0.75,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#000',
+      },
+    }, 'fire-stations-circle')
+  }
+
+  const refreshFires = async (map) => {
+    try {
+      const data = await fetchActiveFires()
+      firesRef.current = data
+      if (map.isStyleLoaded()) {
+        const src = map.getSource('active-fires')
+        if (src) src.setData(data)
+        else addFiresLayer(map, data)
+      }
+    } catch (e) {
+      setError(`fire load failed: ${e.message}`)
+    }
+  }
 
   useEffect(() => {
     if (mapRef.current) return
@@ -20,70 +133,112 @@ export default function FireMap() {
 
     const map = new mapboxgl.Map({
       container: containerRef.current,
-      style: 'mapbox://styles/mapbox/dark-v11',
+      style: STYLES[theme],
       center: [-119.5, 37.0],
       zoom: 6,
     })
     mapRef.current = map
+
+    const popup = new mapboxgl.Popup({ closeButton: false, offset: 12 })
+    map.on('mouseenter', 'fire-stations-circle', (e) => {
+      map.getCanvas().style.cursor = 'pointer'
+      const f = e.features[0]
+      const { name, station_id, available, units } = f.properties
+      popup
+        .setLngLat(f.geometry.coordinates)
+        .setHTML(
+          `<strong>${name}</strong><br/>` +
+          `${station_id}<br/>` +
+          `Status: ${available === true || available === 'true' ? 'available' : 'deployed'}<br/>` +
+          `Units: ${units}`
+        )
+        .addTo(map)
+    })
+    map.on('mouseleave', 'fire-stations-circle', () => {
+      map.getCanvas().style.cursor = ''
+      popup.remove()
+    })
 
     map.on('load', async () => {
       try {
         const res = await fetch(STATIONS_URL)
         if (!res.ok) throw new Error(`failed to load stations (${res.status})`)
         const data = await res.json()
-
-        map.addSource('fire-stations', { type: 'geojson', data })
-
-        // Color-coded dots: green = available, red = deployed/unavailable.
-        map.addLayer({
-          id: 'fire-stations-circle',
-          type: 'circle',
-          source: 'fire-stations',
-          paint: {
-            'circle-radius': 7,
-            'circle-color': [
-              'case',
-              ['==', ['get', 'available'], true], '#22cc44',
-              '#ff3322',
-            ],
-            'circle-stroke-width': 1.5,
-            'circle-stroke-color': '#ffffff',
-          },
-        })
-
-        const popup = new mapboxgl.Popup({ closeButton: false, offset: 12 })
-        map.on('mouseenter', 'fire-stations-circle', (e) => {
-          map.getCanvas().style.cursor = 'pointer'
-          const f = e.features[0]
-          const { name, station_id, available, units } = f.properties
-          popup
-            .setLngLat(f.geometry.coordinates)
-            .setHTML(
-              `<strong>${name}</strong><br/>` +
-              `${station_id}<br/>` +
-              `Status: ${available === true || available === 'true' ? 'available' : 'deployed'}<br/>` +
-              `Units: ${units}`
-            )
-            .addTo(map)
-        })
-        map.on('mouseleave', 'fire-stations-circle', () => {
-          map.getCanvas().style.cursor = ''
-          popup.remove()
-        })
+        stationsRef.current = data
+        addStationsLayer(map, data)
       } catch (e) {
         setError(`station load failed: ${e.message}`)
       }
+      await refreshFires(map)
     })
 
+    const interval = setInterval(() => refreshFires(map), FIRE_REFRESH_MS)
+
+    const firePopup = new mapboxgl.Popup({ closeButton: false, offset: 8 })
+    const showFirePopup = (e) => {
+      map.getCanvas().style.cursor = 'pointer'
+      const f = e.features[0]
+      const p = f.properties
+      const lines = [
+        `<strong>${p.name || 'Unnamed fire'}</strong>`,
+        p.location ? `${p.location}` : null,
+        p.county ? `County: ${p.county}` : null,
+        `Containment: ${p.containment_pct}%`,
+        p.acres_burned ? `Acres burned: ${Number(p.acres_burned).toLocaleString()}` : null,
+        p.spread_rate_km2_per_hr ? `Spread: ${p.spread_rate_km2_per_hr} km²/hr` : null,
+        `<span style="color:#666;font-size:11px">Updated ${formatRelative(p.last_updated)}</span>`,
+      ].filter(Boolean)
+      firePopup.setLngLat(e.lngLat).setHTML(lines.join('<br/>')).addTo(map)
+    }
+    const hideFirePopup = () => {
+      map.getCanvas().style.cursor = ''
+      firePopup.remove()
+    }
+    for (const layer of ['fires-fill', 'fires-circle']) {
+      map.on('mouseenter', layer, showFirePopup)
+      map.on('mouseleave', layer, hideFirePopup)
+    }
+
     return () => {
+      clearInterval(interval)
       map.remove()
       mapRef.current = null
     }
   }, [])
 
+  // Swap basemap on theme change; re-attach stations once the new style settles.
+  // Skip the first run — the map constructor already loaded the initial theme.
+  useEffect(() => {
+    if (!didInitTheme.current) {
+      didInitTheme.current = true
+      return
+    }
+    const map = mapRef.current
+    if (!map) return
+
+    map.setStyle(STYLES[theme])
+    map.once('style.load', () => {
+      if (stationsRef.current) addStationsLayer(map, stationsRef.current)
+      if (firesRef.current) addFiresLayer(map, firesRef.current)
+    })
+  }, [theme])
+
   return (
     <div style={{ position: 'relative', width: '100%', height: '100vh' }}>
       <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+      <button
+        onClick={() => setTheme((t) => (t === 'light' ? 'dark' : 'light'))}
+        style={{
+          position: 'absolute', top: 12, right: 12, padding: '8px 12px',
+          background: theme === 'light' ? '#1a1a1a' : '#f5f5f5',
+          color: theme === 'light' ? '#f5f5f5' : '#1a1a1a',
+          border: 'none', borderRadius: 4, cursor: 'pointer',
+          fontFamily: 'monospace', fontSize: 13, fontWeight: 600,
+          boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+        }}
+      >
+        {theme === 'light' ? 'Dark' : 'Light'}
+      </button>
       {error && (
         <div style={{
           position: 'absolute', top: 12, left: 12, padding: '8px 12px',

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -58,11 +58,10 @@ export default function FireMap() {
     })
   }
 
-  // Fire perimeter fill + outline (for polygons) and circle (for points).
-  // CAL FIRE live data is point-only; mock demo data is polygons. One source,
-  // two layer types filtered by geometry. Color interpolates by containment.
+  // Fire perimeter fill + outline. Polygon footprint is scaled by acres burned
+  // (see api/fires.js). Color interpolates by containment (red→green).
   const addFiresLayer = (map, data) => {
-    for (const id of ['fires-fill', 'fires-outline', 'fires-circle']) {
+    for (const id of ['fires-fill', 'fires-outline']) {
       if (map.getLayer(id)) map.removeLayer(id)
     }
     if (map.getSource('active-fires')) map.removeSource('active-fires')
@@ -90,23 +89,6 @@ export default function FireMap() {
       source: 'active-fires',
       filter: ['==', ['geometry-type'], 'Polygon'],
       paint: { 'line-color': '#000', 'line-width': 1.2, 'line-opacity': 0.4 },
-    }, 'fire-stations-circle')
-    map.addLayer({
-      id: 'fires-circle',
-      type: 'circle',
-      source: 'active-fires',
-      filter: ['==', ['geometry-type'], 'Point'],
-      paint: {
-        'circle-radius': [
-          'interpolate', ['linear'], ['zoom'],
-          5, 6,
-          10, 14,
-        ],
-        'circle-color': containmentColor,
-        'circle-opacity': 0.75,
-        'circle-stroke-width': 2,
-        'circle-stroke-color': '#000',
-      },
     }, 'fire-stations-circle')
   }
 
@@ -194,7 +176,7 @@ export default function FireMap() {
       map.getCanvas().style.cursor = ''
       firePopup.remove()
     }
-    for (const layer of ['fires-fill', 'fires-circle']) {
+    for (const layer of ['fires-fill']) {
       map.on('mouseenter', layer, showFirePopup)
       map.on('mouseleave', layer, hideFirePopup)
     }

--- a/frontend/src/api/fires.js
+++ b/frontend/src/api/fires.js
@@ -4,9 +4,47 @@
 //   "true"  → static demo GeoJSON in /public (curated polygons for demo runs)
 //   "false" → live fetch from CAL FIRE's public incident API (current real fires)
 //
-// CAL FIRE returns Point geometries; the FireMap renders points + polygons
-// with the same containment color scheme. Schema is normalized below to the
-// shape our map components expect.
+// CAL FIRE returns Point geometries with AcresBurned. We synthesize a circular
+// polygon sized to the burned area so fires scale visibly on the map — a real
+// perimeter would come from #7's enrichment, but acres+centroid is what the
+// public feed gives us today.
+const ACRES_TO_KM2 = 0.00404686
+const EARTH_RADIUS_KM = 6371
+const CIRCLE_VERTICES = 4
+const MIN_RADIUS_KM = 3      // floor so small fires are visible at statewide zoom
+const VISUAL_SCALE = 4       // exaggerate footprint for demo legibility — a real
+                             // 100-acre fire is ~300m across, invisible at zoom 6
+
+function acresToRadiusKm(acres) {
+  const km2 = Math.max(0, acres) * ACRES_TO_KM2
+  const trueRadius = Math.sqrt(km2 / Math.PI)
+  return Math.max(MIN_RADIUS_KM, trueRadius * VISUAL_SCALE)
+}
+
+// Approximate circle as a 48-sided polygon on the sphere (good enough at the
+// scale of a fire perimeter; ignores ellipsoid).
+function circlePolygon([lon, lat], radiusKm) {
+  const ring = []
+  const angularDist = radiusKm / EARTH_RADIUS_KM
+  const latRad = (lat * Math.PI) / 180
+  const lonRad = (lon * Math.PI) / 180
+  for (let i = 0; i <= CIRCLE_VERTICES; i++) {
+    const bearing = (i / CIRCLE_VERTICES) * 2 * Math.PI
+    const lat2 = Math.asin(
+      Math.sin(latRad) * Math.cos(angularDist) +
+        Math.cos(latRad) * Math.sin(angularDist) * Math.cos(bearing),
+    )
+    const lon2 =
+      lonRad +
+      Math.atan2(
+        Math.sin(bearing) * Math.sin(angularDist) * Math.cos(latRad),
+        Math.cos(angularDist) - Math.sin(latRad) * Math.sin(lat2),
+      )
+    ring.push([(lon2 * 180) / Math.PI, (lat2 * 180) / Math.PI])
+  }
+  return { type: 'Polygon', coordinates: [ring] }
+}
+
 const MOCK_URL = '/data/active_fires.geojson'
 const CALFIRE_URL = '/api/calfire'   // proxied in vite.config.js to bypass CORS
 
@@ -14,9 +52,14 @@ const USE_MOCK = import.meta.env.VITE_USE_MOCK_FIRES === 'true'
 
 function normalizeCalFireFeature(f) {
   const p = f.properties || {}
+  const acres = p.AcresBurned ?? 0
+  const geometry =
+    f.geometry?.type === 'Point'
+      ? circlePolygon(f.geometry.coordinates, acresToRadiusKm(acres))
+      : f.geometry
   return {
     type: 'Feature',
-    geometry: f.geometry,   // CAL FIRE returns Point — map renders as circle
+    geometry,
     properties: {
       fire_id: p.UniqueId,
       name: (p.Name || '').trim(),

--- a/frontend/src/api/fires.js
+++ b/frontend/src/api/fires.js
@@ -1,0 +1,53 @@
+// Active fires data source.
+//
+// Two modes, controlled by VITE_USE_MOCK_FIRES:
+//   "true"  → static demo GeoJSON in /public (curated polygons for demo runs)
+//   "false" → live fetch from CAL FIRE's public incident API (current real fires)
+//
+// CAL FIRE returns Point geometries; the FireMap renders points + polygons
+// with the same containment color scheme. Schema is normalized below to the
+// shape our map components expect.
+const MOCK_URL = '/data/active_fires.geojson'
+const CALFIRE_URL = '/api/calfire'   // proxied in vite.config.js to bypass CORS
+
+const USE_MOCK = import.meta.env.VITE_USE_MOCK_FIRES === 'true'
+
+function normalizeCalFireFeature(f) {
+  const p = f.properties || {}
+  return {
+    type: 'Feature',
+    geometry: f.geometry,   // CAL FIRE returns Point — map renders as circle
+    properties: {
+      fire_id: p.UniqueId,
+      name: (p.Name || '').trim(),
+      containment_pct: p.PercentContained ?? 0,
+      acres_burned: p.AcresBurned ?? 0,
+      county: p.County,
+      location: p.Location,
+      detected_at: p.Started,
+      last_updated: p.Updated,
+      url: p.Url,
+      // spread_rate isn't in the CAL FIRE feed — leave undefined; popup tolerates it
+    },
+  }
+}
+
+async function fetchMock() {
+  const res = await fetch(MOCK_URL, { cache: 'no-store' })
+  if (!res.ok) throw new Error(`failed to fetch mock fires (${res.status})`)
+  return res.json()
+}
+
+async function fetchLive() {
+  const res = await fetch(CALFIRE_URL, { cache: 'no-store' })
+  if (!res.ok) throw new Error(`failed to fetch CAL FIRE (${res.status})`)
+  const raw = await res.json()
+  const features = (raw.features || [])
+    .filter((f) => f?.properties?.IsActive)
+    .map(normalizeCalFireFeature)
+  return { type: 'FeatureCollection', features }
+}
+
+export async function fetchActiveFires() {
+  return USE_MOCK ? fetchMock() : fetchLive()
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,5 +3,16 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  server: { port: 3000 },
+  server: {
+    port: 3000,
+    // Dev proxy to bypass CORS when calling fire.ca.gov directly from the browser.
+    // Production swaps this for the real API Gateway endpoint (#30).
+    proxy: {
+      '/api/calfire': {
+        target: 'https://incidents.fire.ca.gov',
+        changeOrigin: true,
+        rewrite: () => '/umbraco/api/IncidentApi/GeoJsonList?inactive=false',
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Adds active-fires layer color-coded by containment (red→green) on top of the existing station map from #25
- Live data from CAL FIRE's public incident GeoJSON (proxied through Vite to bypass CORS); 30s polling
- `VITE_USE_MOCK_FIRES=true` swaps to curated demo polygons in `public/data/active_fires.geojson` for demo runs
- CAL FIRE returns Point + AcresBurned only — synthesizes a polygon centered on the point, sized to the burned area, so live and mock fires render in the same fill+outline style. Visual scale + min-radius floor keep small fires legible at the statewide zoom
- Popup shows name, location, county, containment %, acres, and "Updated Xm ago"

## Notes
- Real perimeters would come from #7 (CAL FIRE poller / WFIGS) — synth is the demo-time stand-in
- Production note: swap Vite proxy for API Gateway endpoint when #30 lands

## Test plan
- [ ] `npm run dev` in `frontend/`, confirm live CAL FIRE incidents render as containment-colored polygons sized to acreage
- [ ] Hover popup shows containment + relative last-updated time
- [ ] Set `VITE_USE_MOCK_FIRES=true`, confirm 5 demo polygons render with correct color scale
- [ ] Theme toggle still re-attaches both station and fire layers

Closes #26