### PR TITLE
[#28] Dispatch panel — advisory, confidence badge, dispatched units

### DIFF
--- a/docs/FIRE_SPREAD_PREDICTION.md
+++ b/docs/FIRE_SPREAD_PREDICTION.md
@@ -1,0 +1,100 @@
+# Fire Spread Prediction — Implementation Brief
+
+**Owner:** _TBD_
+**Target:** Predict next-hour fire perimeter + spread rate for enriched fire events so the dispatch model and resident alerts can reason about *where the fire is going*, not just where it is.
+
+## Scope
+
+Add a `predict_spread` Lambda that consumes enriched fire events from Kinesis and emits a `spread_forecast` payload (cone polygon + rate + confidence) onto the same stream for downstream consumers (#9 dispatch model, #22 alert sender).
+
+Output schema (added to enriched event):
+
+```json
+{
+  "spread_forecast": {
+    "rate_km_per_hr": float,
+    "bearing_deg": float,
+    "cone_geojson": "GeoJSON Polygon string",
+    "horizon_minutes": 60,
+    "confidence": float,
+    "model_version": "spread-v1"
+  }
+}
+```
+
+Confidence must feed the existing 0.65 gate (CLAUDE.md rule 3). If `confidence < 0.65`, Step Functions pauses for human review before any resident alert.
+
+## Approach — hybrid physics + ML
+
+### Layer 1: Rothermel-style elliptical baseline (deterministic)
+
+Simplified surface-fire spread model. Inputs from the enriched event + NOAA:
+
+- `wind_speed_ms`, `wind_direction_deg` (already enriched)
+- slope (derive from USGS DEM tile at lat/lon — cache per cell)
+- fuel moisture proxy (use NOAA RH + days-since-rain; bucket low/med/high)
+- fuel model (LANDFIRE 40 Scott & Burgan — pick nearest 1km cell)
+
+Produce head/flank/back spread rates → project an ellipse over 60 min → GeoJSON polygon.
+
+This gives an **explainable baseline** that always runs, even if the ML layer fails. Critical for the AI-safety track.
+
+### Layer 2: SageMaker residual correction (ML)
+
+Train a gradient-boosted regressor (XGBoost built-in SageMaker container — cheap, fast) to predict the **residual** between the Rothermel rate and observed spread from FIRMS historical detections.
+
+- Features: wind, RH, temp, fuel model, slope, radiative_power, containment_pct, hour-of-day, month
+- Label: (observed next-detection spread rate) − (Rothermel predicted rate)
+- Final prediction = Rothermel rate + ML residual
+- Confidence = `1 − normalized_prediction_interval_width` (quantile regression or bootstrap)
+
+Using residuals (not raw rate) keeps the physics interpretable and means a broken model degrades to the baseline, not to garbage.
+
+## Roadmap
+
+### Phase 1 — Baseline only (half day)
+1. `functions/ml/spread_predictor/handler.py` — Rothermel ellipse from enriched event, emit `spread_forecast` with fixed `confidence=0.5` (forces human review until ML ships).
+2. Cache DEM slope + LANDFIRE fuel lookups in S3 as pre-computed 1km grid JSON — no runtime GIS calls.
+3. Unit tests: known-input ellipse, zero-wind (circle), high-wind elongation.
+4. Wire into enrichment Lambda output. Verify end-to-end on a demo fire.
+
+### Phase 2 — Training data (half day)
+1. Pull 2 years of FIRMS detections for CA from S3 (already used by #12).
+2. Build training rows: for each detection, find same-fire detection ~60 min later, compute observed spread rate + bearing.
+3. Join weather at detection time (NOAA historical) + slope/fuel grids.
+4. Drop to Parquet in the ML bucket.
+
+### Phase 3 — Model (1 day)
+1. SageMaker XGBoost training job on the Parquet dataset. Target = residual.
+2. Quantile regression (`reg:quantileerror` with α=0.1, 0.5, 0.9) for prediction intervals.
+3. Deploy to same SageMaker endpoint pattern as #13 (separate variant or new endpoint — coordinate with #13 owner).
+4. Add model call to the Lambda; fall back to baseline on any error/timeout (hard timeout 400ms).
+
+### Phase 4 — Safety + validation (half day)
+1. Log every prediction (input features + baseline + ML residual + final + confidence) to the hash-chain audit table (#17).
+2. Run Clarify bias audit across geography buckets (coastal/inland/mountain) — piggyback on #18.
+3. Set Model Monitor baseline (#20).
+4. Confirm Step Functions gate trips correctly when confidence < 0.65 (#19).
+
+## Hard constraints
+
+- **No PII.** Not a concern here — no resident data touches this pipeline, but don't add any.
+- **Audit first.** Spread prediction result logged to `wildfire-watch-audit` before the event is re-published to Kinesis. See CLAUDE.md rule 1 and issue #32.
+- **Fallback is mandatory.** If the SageMaker endpoint is down, baseline-only must still publish (with reduced confidence so the gate catches it).
+- **Budget:** runtime < 500ms per event; training job < $15.
+
+## Open questions for the team
+
+1. New SageMaker endpoint or multi-model endpoint with #13? (cost vs. isolation)
+2. Horizon: is 60 min the right window for the demo narrative, or do we want 30 / 60 / 120 min tiers?
+3. Do we surface the cone on the frontend map (issue #27 alert-zone overlay already lays groundwork) or keep it internal-only for v1?
+
+## Suggested GitHub issues to file
+
+- `[ml] Implement Rothermel baseline spread Lambda` — depends on #6 (enrichment), blocks ML layer
+- `[ml] Build FIRMS historical spread training dataset` — depends on #2
+- `[ml] Train + deploy XGBoost spread residual model` — depends on the dataset issue
+- `[safety] Hash-chain audit spread predictions` — depends on #17
+- `[frontend] Render spread cone on map` — depends on baseline Lambda, optional for demo
+
+File these under the existing ML (12–15) / Safety (16–21) sections of `docs/ISSUES.md` so the dependency graph stays coherent.

--- a/frontend/public/data/active_fires.geojson
+++ b/frontend/public/data/active_fires.geojson
@@ -1,235 +1,81 @@
 {
   "type": "FeatureCollection",
+  "_comment": "Demo dataset. Five fires spanning the full size + containment spectrum so the UI shows differentiated footprints, alert halos, and evac routes. Toggled by VITE_USE_MOCK_FIRES=true.",
   "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "fire_id": "demo-malibu-grass",
+        "name": "Pacific Coast Grass Fire",
+        "containment_pct": 85,
+        "acres_burned": 220,
+        "spread_rate_km2_per_hr": 0.3,
+        "county": "Los Angeles",
+        "location": "PCH near Topanga Canyon Blvd",
+        "detected_at": "2026-04-18T18:42:00Z",
+        "last_updated": "2026-04-18T20:35:00Z"
+      },
+      "geometry": { "type": "Point", "coordinates": [-118.587, 34.04] }
+    },
     {
       "type": "Feature",
       "properties": {
         "fire_id": "demo-thousand-oaks",
         "name": "Thousand Oaks Fire",
-        "containment_pct": 15,
-        "spread_rate_km2_per_hr": 2.1,
+        "containment_pct": 45,
+        "acres_burned": 1800,
+        "spread_rate_km2_per_hr": 1.4,
+        "county": "Ventura",
+        "location": "Conejo Valley, north of US-101",
         "detected_at": "2026-04-18T14:00:00Z",
-        "last_updated": "2026-04-18T20:13:34.028940Z"
+        "last_updated": "2026-04-18T20:30:00Z"
       },
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              -118.85,
-              34.18
-            ],
-            [
-              -118.82,
-              34.19
-            ],
-            [
-              -118.81,
-              34.17
-            ],
-            [
-              -118.82,
-              34.15
-            ],
-            [
-              -118.85,
-              34.15
-            ],
-            [
-              -118.86,
-              34.17
-            ],
-            [
-              -118.85,
-              34.18
-            ]
-          ]
-        ]
-      }
+      "geometry": { "type": "Point", "coordinates": [-118.835, 34.21] }
     },
     {
       "type": "Feature",
       "properties": {
-        "fire_id": "demo-malibu",
-        "name": "Malibu Coastal Fire",
-        "containment_pct": 35,
-        "spread_rate_km2_per_hr": 3.4,
-        "detected_at": "2026-04-18T11:30:00Z",
-        "last_updated": "2026-04-18T20:13:34.028940Z"
-      },
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              -118.8,
-              34.04
-            ],
-            [
-              -118.76,
-              34.05
-            ],
-            [
-              -118.74,
-              34.03
-            ],
-            [
-              -118.75,
-              34.01
-            ],
-            [
-              -118.79,
-              34.0
-            ],
-            [
-              -118.81,
-              34.02
-            ],
-            [
-              -118.8,
-              34.04
-            ]
-          ]
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "fire_id": "demo-big-bear",
-        "name": "Big Bear Ridge Fire",
-        "containment_pct": 65,
-        "spread_rate_km2_per_hr": 0.8,
-        "detected_at": "2026-04-17T22:15:00Z",
-        "last_updated": "2026-04-18T20:13:34.028940Z"
-      },
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              -116.94,
-              34.27
-            ],
-            [
-              -116.9,
-              34.28
-            ],
-            [
-              -116.88,
-              34.26
-            ],
-            [
-              -116.89,
-              34.24
-            ],
-            [
-              -116.93,
-              34.23
-            ],
-            [
-              -116.95,
-              34.25
-            ],
-            [
-              -116.94,
-              34.27
-            ]
-          ]
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "fire_id": "demo-inland-empire",
-        "name": "Inland Empire Industrial",
-        "containment_pct": 5,
+        "fire_id": "demo-cleveland-nf",
+        "name": "Cleveland NF Complex",
+        "containment_pct": 20,
+        "acres_burned": 9500,
         "spread_rate_km2_per_hr": 4.2,
-        "detected_at": "2026-04-18T16:45:00Z",
-        "last_updated": "2026-04-18T20:13:34.028940Z"
+        "county": "San Diego",
+        "location": "Cleveland National Forest, east of Ramona",
+        "detected_at": "2026-04-17T22:15:00Z",
+        "last_updated": "2026-04-18T20:33:00Z"
       },
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              -117.32,
-              34.06
-            ],
-            [
-              -117.27,
-              34.07
-            ],
-            [
-              -117.25,
-              34.05
-            ],
-            [
-              -117.26,
-              34.02
-            ],
-            [
-              -117.3,
-              34.01
-            ],
-            [
-              -117.33,
-              34.03
-            ],
-            [
-              -117.32,
-              34.06
-            ]
-          ]
-        ]
-      }
+      "geometry": { "type": "Point", "coordinates": [-116.81, 33.04] }
     },
     {
       "type": "Feature",
       "properties": {
-        "fire_id": "demo-shasta",
-        "name": "Shasta Trinity Fire",
-        "containment_pct": 88,
-        "spread_rate_km2_per_hr": 0.2,
-        "detected_at": "2026-04-16T09:00:00Z",
-        "last_updated": "2026-04-18T20:13:34.028940Z"
+        "fire_id": "demo-sierra-foothills",
+        "name": "Sierra Foothills Fire",
+        "containment_pct": 12,
+        "acres_burned": 28000,
+        "spread_rate_km2_per_hr": 6.8,
+        "county": "Fresno",
+        "location": "Sierra National Forest, Big Creek drainage",
+        "detected_at": "2026-04-17T09:00:00Z",
+        "last_updated": "2026-04-18T20:31:00Z"
       },
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-          [
-            [
-              -122.42,
-              40.61
-            ],
-            [
-              -122.36,
-              40.62
-            ],
-            [
-              -122.34,
-              40.59
-            ],
-            [
-              -122.36,
-              40.56
-            ],
-            [
-              -122.41,
-              40.56
-            ],
-            [
-              -122.43,
-              40.58
-            ],
-            [
-              -122.42,
-              40.61
-            ]
-          ]
-        ]
-      }
+      "geometry": { "type": "Point", "coordinates": [-119.25, 37.20] }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fire_id": "demo-shasta-megafire",
+        "name": "Shasta Megafire",
+        "containment_pct": 4,
+        "acres_burned": 78000,
+        "spread_rate_km2_per_hr": 11.5,
+        "county": "Shasta",
+        "location": "Whiskeytown, west of Redding",
+        "detected_at": "2026-04-15T11:00:00Z",
+        "last_updated": "2026-04-18T20:29:00Z"
+      },
+      "geometry": { "type": "Point", "coordinates": [-122.62, 40.62] }
     }
   ]
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import FireMap from './FireMap'
 import DispatchPanel from './DispatchPanel'
+import RegisterModal from './RegisterModal'
 
 export default function App() {
   // Selection + theme are owned at the app level so the map and the side
@@ -8,6 +9,8 @@ export default function App() {
   // selected fire and recolors its chrome to match the active basemap theme.
   const [selectedFire, setSelectedFire] = useState(null)
   const [theme, setTheme] = useState('light')
+  const [registerOpen, setRegisterOpen] = useState(false)
+  const dark = theme === 'dark'
   return (
     <>
       <FireMap
@@ -21,6 +24,38 @@ export default function App() {
         onClose={() => setSelectedFire(null)}
         theme={theme}
       />
+      <button
+        onClick={() => setRegisterOpen(true)}
+        style={{
+          position: 'absolute', top: 12, left: 60, zIndex: 6,
+          padding: '8px 14px', height: 36,
+          background: '#ff5533', color: '#fff',
+          border: 'none', borderRadius: 999, cursor: 'pointer',
+          fontSize: 13, fontWeight: 600, letterSpacing: 0.3,
+          fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+          boxShadow: dark ? '0 2px 8px rgba(0,0,0,0.5)' : '0 2px 8px rgba(255,85,51,0.35)',
+          display: 'flex', alignItems: 'center', gap: 6,
+        }}
+      >
+        <BellIcon />
+        Get SMS alerts
+      </button>
+      <RegisterModal
+        open={registerOpen}
+        onClose={() => setRegisterOpen(false)}
+        theme={theme}
+      />
     </>
+  )
+}
+
+function BellIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true">
+      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+    </svg>
   )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,13 +3,24 @@ import FireMap from './FireMap'
 import DispatchPanel from './DispatchPanel'
 
 export default function App() {
-  // Selection is owned at the app level so the map and the side panel stay in
-  // sync. FireMap reports clicks, the panel renders the selected fire's data.
+  // Selection + theme are owned at the app level so the map and the side
+  // panel stay in sync. FireMap reports clicks; the panel renders the
+  // selected fire and recolors its chrome to match the active basemap theme.
   const [selectedFire, setSelectedFire] = useState(null)
+  const [theme, setTheme] = useState('light')
   return (
     <>
-      <FireMap selectedFire={selectedFire} onSelectFire={setSelectedFire} />
-      <DispatchPanel fire={selectedFire} onClose={() => setSelectedFire(null)} />
+      <FireMap
+        selectedFire={selectedFire}
+        onSelectFire={setSelectedFire}
+        theme={theme}
+        onThemeChange={setTheme}
+      />
+      <DispatchPanel
+        fire={selectedFire}
+        onClose={() => setSelectedFire(null)}
+        theme={theme}
+      />
     </>
   )
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,15 @@
+import { useState } from 'react'
 import FireMap from './FireMap'
+import DispatchPanel from './DispatchPanel'
 
 export default function App() {
-  return <FireMap />
+  // Selection is owned at the app level so the map and the side panel stay in
+  // sync. FireMap reports clicks, the panel renders the selected fire's data.
+  const [selectedFire, setSelectedFire] = useState(null)
+  return (
+    <>
+      <FireMap selectedFire={selectedFire} onSelectFire={setSelectedFire} />
+      <DispatchPanel fire={selectedFire} onClose={() => setSelectedFire(null)} />
+    </>
+  )
 }

--- a/frontend/src/DispatchPanel.jsx
+++ b/frontend/src/DispatchPanel.jsx
@@ -1,13 +1,58 @@
 import { useEffect, useState } from 'react'
 import { fetchDispatchData } from './api/dispatch'
 
-// Confidence badge color follows the CLAUDE.md safety contract: <0.65 routes
-// to human review (red), 0.65-0.85 is auto-dispatch but flagged (amber), and
-// ≥0.85 is high-confidence auto-dispatch (green).
-function confidenceTone(score) {
-  if (score < 0.65) return { color: '#ff3322', label: 'HUMAN REVIEW REQUIRED' }
-  if (score < 0.85) return { color: '#ffaa00', label: 'AUTO-DISPATCH (FLAGGED)' }
-  return { color: '#22cc44', label: 'AUTO-DISPATCH' }
+// Resident-facing safety badge. Frames the CLAUDE.md confidence gate from the
+// resident's perspective ("we don't bother you unless we're sure") rather than
+// the dispatcher's ("Step Functions paused for review").
+function safetyTone(score) {
+  if (score < 0.65) {
+    return {
+      color: '#ff8800',
+      label: 'NO ALERT SENT',
+      reason: `AI confidence ${(score * 100).toFixed(0)}% is below our 65% safety threshold.`,
+      action: 'No SMS goes out until a human reviews this fire — we don\'t want false alarms waking you up.',
+    }
+  }
+  if (score < 0.85) {
+    return {
+      color: '#22aa66',
+      label: 'ALERT SENT',
+      reason: `Confidence ${(score * 100).toFixed(0)}%. Above the 65% gate, flagged for post-incident audit.`,
+      action: 'SMS dispatched to residents in the alert zone. Recommend you act on the evac guidance below.',
+    }
+  }
+  return {
+    color: '#0e8a4e',
+    label: 'ALERT SENT (HIGH CONFIDENCE)',
+    reason: `Confidence ${(score * 100).toFixed(0)}%. Passed Bedrock Guardrails and the safety gate.`,
+    action: 'SMS dispatched. This is a verified, high-confidence threat — please follow the evac guidance below.',
+  }
+}
+
+// Dispatcher view tone — kept for the AI-safety track demo.
+function dispatcherTone(score) {
+  if (score < 0.65) {
+    return {
+      color: '#ff3322',
+      label: 'HUMAN REVIEW REQUIRED',
+      reason: `Dispatch confidence ${(score * 100).toFixed(0)}% is below the 65% safety threshold.`,
+      action: 'Step Functions has paused this advisory. No resources will mobilize until a dispatcher approves it.',
+    }
+  }
+  if (score < 0.85) {
+    return {
+      color: '#ffaa00',
+      label: 'AUTO-DISPATCH (FLAGGED)',
+      reason: `Confidence ${(score * 100).toFixed(0)}% is above the 65% gate but below the 85% high-confidence band.`,
+      action: 'Resources are being dispatched automatically. The advisory is flagged for post-incident audit review.',
+    }
+  }
+  return {
+    color: '#22cc44',
+    label: 'AUTO-DISPATCH',
+    reason: `High confidence (${(score * 100).toFixed(0)}%). Model output passed Bedrock Guardrails and the safety gate.`,
+    action: 'Auto-dispatched and written to the immutable audit chain.',
+  }
 }
 
 const STATUS_TONE = {
@@ -16,9 +61,17 @@ const STATUS_TONE = {
   staged: '#888',
 }
 
+function timeAgo(iso) {
+  const min = Math.max(1, Math.round((Date.now() - new Date(iso).getTime()) / 60_000))
+  if (min < 60) return `${min} min ago`
+  const hr = Math.round(min / 60)
+  return `${hr}h ago`
+}
+
 export default function DispatchPanel({ fire, onClose }) {
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [view, setView] = useState('resident')
 
   useEffect(() => {
     if (!fire) {
@@ -33,31 +86,117 @@ export default function DispatchPanel({ fire, onClose }) {
     return () => { cancelled = true }
   }, [fire?.properties?.fire_id])
 
+  // Less intrusive empty state — a small floating chip in the corner instead
+  // of a full panel. Nudges the user without occupying a third of the map.
   if (!fire) {
     return (
-      <aside style={panelStyle}>
-        <div style={emptyStyle}>
-          <div style={{ fontSize: 32, marginBottom: 8 }}>📍</div>
-          <div>Click a fire on the map to see dispatch details.</div>
-        </div>
-      </aside>
+      <div style={emptyChipStyle}>
+        <span style={{ fontSize: 14 }}>📍</span>
+        <span>Click a fire for details</span>
+      </div>
     )
   }
 
   const p = fire.properties
-  const tone = data ? confidenceTone(data.confidence) : null
 
   return (
     <aside style={panelStyle}>
       <header style={headerStyle}>
         <div style={{ minWidth: 0, flex: 1 }}>
-          <div style={{ fontSize: 11, opacity: 0.6, letterSpacing: 1 }}>DISPATCH PANEL</div>
+          <div style={{ fontSize: 11, opacity: 0.6, letterSpacing: 1 }}>
+            {view === 'resident' ? 'COMMUNITY ALERT' : 'DISPATCH PANEL'}
+          </div>
           <h2 style={{ margin: '4px 0 0', fontSize: 18, color: '#111' }}>{p.name}</h2>
           {p.location && <div style={{ fontSize: 12, color: '#555' }}>{p.location}</div>}
         </div>
         <button onClick={onClose} style={closeBtnStyle} aria-label="Close panel">×</button>
       </header>
 
+      <div style={tabBarStyle}>
+        <Tab active={view === 'resident'} onClick={() => setView('resident')}>Resident</Tab>
+        <Tab active={view === 'dispatcher'} onClick={() => setView('dispatcher')}>Dispatcher</Tab>
+      </div>
+
+      {loading && <div style={loadingStyle}>Loading…</div>}
+
+      {view === 'resident' ? (
+        <ResidentView fire={fire} data={data} />
+      ) : (
+        <DispatcherView fire={fire} data={data} />
+      )}
+
+      <footer style={footerStyle}>
+        Stub data — wire to DynamoDB + WebSocket in #30
+      </footer>
+    </aside>
+  )
+}
+
+function ResidentView({ fire, data }) {
+  const p = fire.properties
+  const tone = data ? safetyTone(data.confidence) : null
+  return (
+    <>
+      <Section title="Are you in danger?">
+        <KV k="Distance to fire" v="—" hint="Enable location" />
+        <KV k="Alert radius" v={`${(p.alert_radius_km || 0).toFixed(1)} km`} />
+        {p.spread_rate_km2_per_hr ? (
+          <KV k="Fire spread rate" v={`${p.spread_rate_km2_per_hr} km²/hr`} />
+        ) : null}
+        <KV k="Containment" v={`${p.containment_pct ?? 0}%`} />
+      </Section>
+
+      <Section title="What to do">
+        {p.evacuation_route ? (
+          <div style={evacBoxStyle}>
+            <div style={{ fontSize: 11, color: '#666', marginBottom: 4 }}>EVACUATION ROUTE</div>
+            <div style={{ fontSize: 14, color: '#111', fontWeight: 600 }}>{p.evacuation_route}</div>
+            <div style={{ fontSize: 12, color: '#555', marginTop: 4 }}>
+              Tap the fire on the map to see the live route and current traffic.
+            </div>
+          </div>
+        ) : (
+          <div style={{ fontSize: 13, color: '#555' }}>
+            Stay tuned for evacuation guidance from local officials.
+          </div>
+        )}
+      </Section>
+
+      {data && (
+        <>
+          <Section title="Alert status">
+            <div style={{ ...badgeStyle, background: tone.color }}>{tone.label}</div>
+            <div style={{ ...gateNoteStyle, borderLeft: `3px solid ${tone.color}` }}>
+              <div style={gateNoteReasonStyle}>{tone.reason}</div>
+              <div style={gateNoteActionStyle}>{tone.action}</div>
+            </div>
+            {data.confidence >= 0.65 && (
+              <div style={alertMetaStyle}>
+                <KV k="Residents notified" v={data.alerts_sent.toLocaleString()} />
+                <KV k="Sent" v={timeAgo(data.alert_sent_at)} />
+              </div>
+            )}
+          </Section>
+
+          <Section title="What the AI is saying">
+            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5, color: '#222' }}>
+              {data.advisory}
+            </p>
+            <div style={auditChipStyle} title={data.audit_hash}>
+              ✓ Verified · audit {data.audit_hash.slice(0, 10)}…
+            </div>
+          </Section>
+        </>
+      )}
+    </>
+  )
+}
+
+function DispatcherView({ fire, data }) {
+  const p = fire.properties
+  const tone = data ? dispatcherTone(data.confidence) : null
+  return (
+    <>
       <Section title="Incident">
         <KV k="County" v={p.county || '—'} />
         <KV k="Containment" v={`${p.containment_pct ?? 0}%`} />
@@ -67,15 +206,17 @@ export default function DispatchPanel({ fire, onClose }) {
         ) : null}
       </Section>
 
-      {loading && <div style={loadingStyle}>Loading dispatch data…</div>}
-
       {data && (
         <>
           <Section title="AI Advisory">
             <div style={{ ...badgeStyle, background: tone.color }}>
               {tone.label} · {(data.confidence * 100).toFixed(0)}%
             </div>
-            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5, color: '#222' }}>
+            <div style={{ ...gateNoteStyle, borderLeft: `3px solid ${tone.color}` }}>
+              <div style={gateNoteReasonStyle}>{tone.reason}</div>
+              <div style={gateNoteActionStyle}>{tone.action}</div>
+            </div>
+            <p style={{ margin: '10px 0 0', fontSize: 13, lineHeight: 1.5, color: '#222' }}>
               {data.advisory}
             </p>
           </Section>
@@ -97,11 +238,7 @@ export default function DispatchPanel({ fire, onClose }) {
           </Section>
         </>
       )}
-
-      <footer style={footerStyle}>
-        Stub data — wire to DynamoDB + WebSocket in #30
-      </footer>
-    </aside>
+    </>
   )
 }
 
@@ -114,12 +251,29 @@ function Section({ title, children }) {
   )
 }
 
-function KV({ k, v }) {
+function KV({ k, v, hint }) {
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, padding: '3px 0' }}>
       <span style={{ color: '#666' }}>{k}</span>
-      <span style={{ color: '#111', fontWeight: 500 }}>{v}</span>
+      <span style={{ color: '#111', fontWeight: 500 }}>
+        {v}{hint ? <span style={{ color: '#aaa', fontWeight: 400, marginLeft: 6 }}>({hint})</span> : null}
+      </span>
     </div>
+  )
+}
+
+function Tab({ active, onClick, children }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        ...tabStyle,
+        color: active ? '#111' : '#888',
+        borderBottom: active ? '2px solid #ff5533' : '2px solid transparent',
+      }}
+    >
+      {children}
+    </button>
   )
 }
 
@@ -148,6 +302,15 @@ const closeBtnStyle = {
   background: 'transparent', border: 'none', fontSize: 24, lineHeight: 1,
   cursor: 'pointer', color: '#666', padding: 0, width: 24, height: 24,
 }
+const tabBarStyle = {
+  display: 'flex', borderBottom: '1px solid #e5e5e5',
+  background: '#fafafa',
+}
+const tabStyle = {
+  flex: 1, background: 'transparent', border: 'none',
+  padding: '10px 0', fontSize: 12, fontWeight: 600, letterSpacing: 0.5,
+  textTransform: 'uppercase', cursor: 'pointer',
+}
 const sectionStyle = { padding: '12px 16px', borderBottom: '1px solid #f0f0f0' }
 const sectionTitleStyle = {
   margin: '0 0 8px', fontSize: 11, fontWeight: 700, letterSpacing: 1,
@@ -166,11 +329,31 @@ const statusPillStyle = {
   fontSize: 10, fontWeight: 700, letterSpacing: 0.5, color: '#fff',
   padding: '3px 7px', borderRadius: 3, textTransform: 'uppercase', whiteSpace: 'nowrap',
 }
-const emptyStyle = {
-  padding: 24, textAlign: 'center', color: '#666',
-  fontSize: 13, marginTop: 60,
+const emptyChipStyle = {
+  position: 'absolute', top: 12, right: 12, zIndex: 5,
+  background: 'rgba(255, 255, 255, 0.92)', color: '#444',
+  padding: '6px 12px', borderRadius: 999,
+  fontSize: 12, fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  boxShadow: '0 2px 6px rgba(0, 0, 0, 0.15)',
+  display: 'flex', alignItems: 'center', gap: 6,
+  pointerEvents: 'none',
 }
 const loadingStyle = { padding: '12px 16px', fontSize: 12, color: '#888' }
+const gateNoteStyle = {
+  background: '#fafafa', padding: '8px 10px', borderRadius: 3,
+  marginBottom: 4, fontSize: 12, lineHeight: 1.45,
+}
+const gateNoteReasonStyle = { color: '#222', fontWeight: 600, marginBottom: 3 }
+const gateNoteActionStyle = { color: '#555' }
+const evacBoxStyle = {
+  background: '#f5f9ff', border: '1px solid #d6e6ff',
+  padding: '10px 12px', borderRadius: 4,
+}
+const alertMetaStyle = { marginTop: 8 }
+const auditChipStyle = {
+  marginTop: 10, fontSize: 11, color: '#0e8a4e',
+  fontFamily: 'ui-monospace, Menlo, monospace',
+}
 const footerStyle = {
   padding: '10px 16px', fontSize: 10, color: '#aaa',
   textAlign: 'center', letterSpacing: 0.3,

--- a/frontend/src/DispatchPanel.jsx
+++ b/frontend/src/DispatchPanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { fetchDispatchData } from './api/dispatch'
 
 // Resident-facing safety badge. Frames the CLAUDE.md confidence gate from the
@@ -29,7 +29,6 @@ function safetyTone(score) {
   }
 }
 
-// Dispatcher view tone — kept for the AI-safety track demo.
 function dispatcherTone(score) {
   if (score < 0.65) {
     return {
@@ -61,6 +60,35 @@ const STATUS_TONE = {
   staged: '#888',
 }
 
+// Theme tokens — keeps the rest of the file readable. Light values are the
+// originals; dark values target the same role at the same contrast level
+// against the dark basemap.
+function tokens(theme) {
+  const dark = theme === 'dark'
+  return {
+    panelBg: dark ? 'rgba(24, 24, 26, 0.96)' : 'rgba(255, 255, 255, 0.97)',
+    panelShadow: dark ? '0 4px 16px rgba(0, 0, 0, 0.6)' : '0 4px 16px rgba(0, 0, 0, 0.25)',
+    border: dark ? '#2a2a2d' : '#e5e5e5',
+    borderSoft: dark ? '#222225' : '#f0f0f0',
+    borderInset: dark ? '#1d1d20' : '#f5f5f5',
+    textPrimary: dark ? '#f1f1f3' : '#111',
+    textSecondary: dark ? '#bdbdc2' : '#555',
+    textMuted: dark ? '#9a9aa0' : '#666',
+    textDim: dark ? '#86868c' : '#888',
+    textVeryDim: dark ? '#6c6c72' : '#aaa',
+    eyebrow: dark ? '#cfcfd4' : '#444',
+    tabBarBg: dark ? '#1f1f22' : '#fafafa',
+    tabAccent: '#ff5533',
+    gateNoteBg: dark ? '#1d1d20' : '#fafafa',
+    evacBoxBg: dark ? '#1a2230' : '#f5f9ff',
+    evacBoxBorder: dark ? '#2a3a55' : '#d6e6ff',
+    chipBg: dark ? 'rgba(28, 28, 30, 0.92)' : 'rgba(255, 255, 255, 0.92)',
+    chipText: dark ? '#e0e0e4' : '#444',
+    chipShadow: dark ? '0 2px 6px rgba(0, 0, 0, 0.5)' : '0 2px 6px rgba(0, 0, 0, 0.15)',
+    auditGreen: dark ? '#3fcf83' : '#0e8a4e',
+  }
+}
+
 function timeAgo(iso) {
   const min = Math.max(1, Math.round((Date.now() - new Date(iso).getTime()) / 60_000))
   if (min < 60) return `${min} min ago`
@@ -68,10 +96,11 @@ function timeAgo(iso) {
   return `${hr}h ago`
 }
 
-export default function DispatchPanel({ fire, onClose }) {
+export default function DispatchPanel({ fire, onClose, theme = 'light' }) {
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(false)
   const [view, setView] = useState('resident')
+  const t = useMemo(() => tokens(theme), [theme])
 
   useEffect(() => {
     if (!fire) {
@@ -90,7 +119,15 @@ export default function DispatchPanel({ fire, onClose }) {
   // of a full panel. Nudges the user without occupying a third of the map.
   if (!fire) {
     return (
-      <div style={emptyChipStyle}>
+      <div style={{
+        position: 'absolute', top: 12, right: 12, zIndex: 5,
+        background: t.chipBg, color: t.chipText,
+        padding: '6px 12px', borderRadius: 999,
+        fontSize: 12, fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        boxShadow: t.chipShadow,
+        display: 'flex', alignItems: 'center', gap: 6,
+        pointerEvents: 'none',
+      }}>
         <span style={{ fontSize: 14 }}>📍</span>
         <span>Click a fire for details</span>
       </div>
@@ -100,63 +137,80 @@ export default function DispatchPanel({ fire, onClose }) {
   const p = fire.properties
 
   return (
-    <aside style={panelStyle}>
-      <header style={headerStyle}>
+    <aside style={{
+      position: 'absolute', top: 12, right: 12, bottom: 12, width: 340,
+      background: t.panelBg, borderRadius: 6, boxShadow: t.panelShadow,
+      overflowY: 'auto', zIndex: 5,
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    }}>
+      <header style={{
+        padding: '14px 16px 12px', borderBottom: `1px solid ${t.border}`,
+        display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8,
+      }}>
         <div style={{ minWidth: 0, flex: 1 }}>
-          <div style={{ fontSize: 11, opacity: 0.6, letterSpacing: 1 }}>
+          <div style={{ fontSize: 11, color: t.eyebrow, letterSpacing: 1, fontWeight: 600 }}>
             {view === 'resident' ? 'COMMUNITY ALERT' : 'DISPATCH PANEL'}
           </div>
-          <h2 style={{ margin: '4px 0 0', fontSize: 18, color: '#111' }}>{p.name}</h2>
-          {p.location && <div style={{ fontSize: 12, color: '#555' }}>{p.location}</div>}
+          <h2 style={{ margin: '4px 0 0', fontSize: 18, color: t.textPrimary }}>{p.name}</h2>
+          {p.location && <div style={{ fontSize: 12, color: t.textSecondary }}>{p.location}</div>}
         </div>
-        <button onClick={onClose} style={closeBtnStyle} aria-label="Close panel">×</button>
+        <button onClick={onClose} aria-label="Close panel" style={{
+          background: 'transparent', border: 'none', fontSize: 24, lineHeight: 1,
+          cursor: 'pointer', color: t.textMuted, padding: 0, width: 24, height: 24,
+        }}>×</button>
       </header>
 
-      <div style={tabBarStyle}>
-        <Tab active={view === 'resident'} onClick={() => setView('resident')}>Resident</Tab>
-        <Tab active={view === 'dispatcher'} onClick={() => setView('dispatcher')}>Dispatcher</Tab>
+      <div style={{ display: 'flex', borderBottom: `1px solid ${t.border}`, background: t.tabBarBg }}>
+        <Tab t={t} active={view === 'resident'} onClick={() => setView('resident')}>Resident</Tab>
+        <Tab t={t} active={view === 'dispatcher'} onClick={() => setView('dispatcher')}>Dispatcher</Tab>
       </div>
 
-      {loading && <div style={loadingStyle}>Loading…</div>}
+      {loading && <div style={{ padding: '12px 16px', fontSize: 12, color: t.textDim }}>Loading…</div>}
 
       {view === 'resident' ? (
-        <ResidentView fire={fire} data={data} />
+        <ResidentView fire={fire} data={data} t={t} />
       ) : (
-        <DispatcherView fire={fire} data={data} />
+        <DispatcherView fire={fire} data={data} t={t} />
       )}
 
-      <footer style={footerStyle}>
+      <footer style={{
+        padding: '10px 16px', fontSize: 10, color: t.textVeryDim,
+        textAlign: 'center', letterSpacing: 0.3,
+      }}>
         Stub data — wire to DynamoDB + WebSocket in #30
       </footer>
     </aside>
   )
 }
 
-function ResidentView({ fire, data }) {
+function ResidentView({ fire, data, t }) {
   const p = fire.properties
   const tone = data ? safetyTone(data.confidence) : null
   return (
     <>
-      <Section title="Are you in danger?">
-        <KV k="Distance to fire" v="—" hint="Enable location" />
-        <KV k="Alert radius" v={`${(p.alert_radius_km || 0).toFixed(1)} km`} />
+      <Section t={t} title="Are you in danger?">
+        <KV t={t} k="Distance to fire" v="—" hint="Enable location" />
+        <KV t={t} k="Alert radius" v={`${(p.alert_radius_km || 0).toFixed(1)} km`} />
         {p.spread_rate_km2_per_hr ? (
-          <KV k="Fire spread rate" v={`${p.spread_rate_km2_per_hr} km²/hr`} />
+          <KV t={t} k="Fire spread rate" v={`${p.spread_rate_km2_per_hr} km²/hr`} />
         ) : null}
-        <KV k="Containment" v={`${p.containment_pct ?? 0}%`} />
+        <KV t={t} k="Containment" v={`${p.containment_pct ?? 0}%`} />
       </Section>
 
-      <Section title="What to do">
+      <Section t={t} title="What to do">
         {p.evacuation_route ? (
-          <div style={evacBoxStyle}>
-            <div style={{ fontSize: 11, color: '#666', marginBottom: 4 }}>EVACUATION ROUTE</div>
-            <div style={{ fontSize: 14, color: '#111', fontWeight: 600 }}>{p.evacuation_route}</div>
-            <div style={{ fontSize: 12, color: '#555', marginTop: 4 }}>
+          <div style={{
+            background: t.evacBoxBg, border: `1px solid ${t.evacBoxBorder}`,
+            padding: '10px 12px', borderRadius: 4,
+          }}>
+            <div style={{ fontSize: 11, color: t.textMuted, marginBottom: 4 }}>EVACUATION ROUTE</div>
+            <div style={{ fontSize: 14, color: t.textPrimary, fontWeight: 600 }}>{p.evacuation_route}</div>
+            <div style={{ fontSize: 12, color: t.textSecondary, marginTop: 4 }}>
               Tap the fire on the map to see the live route and current traffic.
             </div>
           </div>
         ) : (
-          <div style={{ fontSize: 13, color: '#555' }}>
+          <div style={{ fontSize: 13, color: t.textSecondary }}>
             Stay tuned for evacuation guidance from local officials.
           </div>
         )}
@@ -164,25 +218,25 @@ function ResidentView({ fire, data }) {
 
       {data && (
         <>
-          <Section title="Alert status">
-            <div style={{ ...badgeStyle, background: tone.color }}>{tone.label}</div>
-            <div style={{ ...gateNoteStyle, borderLeft: `3px solid ${tone.color}` }}>
-              <div style={gateNoteReasonStyle}>{tone.reason}</div>
-              <div style={gateNoteActionStyle}>{tone.action}</div>
-            </div>
+          <Section t={t} title="Alert status">
+            <Badge color={tone.color}>{tone.label}</Badge>
+            <GateNote t={t} tone={tone} />
             {data.confidence >= 0.65 && (
-              <div style={alertMetaStyle}>
-                <KV k="Residents notified" v={data.alerts_sent.toLocaleString()} />
-                <KV k="Sent" v={timeAgo(data.alert_sent_at)} />
+              <div style={{ marginTop: 8 }}>
+                <KV t={t} k="Residents notified" v={data.alerts_sent.toLocaleString()} />
+                <KV t={t} k="Sent" v={timeAgo(data.alert_sent_at)} />
               </div>
             )}
           </Section>
 
-          <Section title="What the AI is saying">
-            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5, color: '#222' }}>
+          <Section t={t} title="What the AI is saying">
+            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5, color: t.textPrimary }}>
               {data.advisory}
             </p>
-            <div style={auditChipStyle} title={data.audit_hash}>
+            <div title={data.audit_hash} style={{
+              marginTop: 10, fontSize: 11, color: t.auditGreen,
+              fontFamily: 'ui-monospace, Menlo, monospace',
+            }}>
               ✓ Verified · audit {data.audit_hash.slice(0, 10)}…
             </div>
           </Section>
@@ -192,45 +246,47 @@ function ResidentView({ fire, data }) {
   )
 }
 
-function DispatcherView({ fire, data }) {
+function DispatcherView({ fire, data, t }) {
   const p = fire.properties
   const tone = data ? dispatcherTone(data.confidence) : null
   return (
     <>
-      <Section title="Incident">
-        <KV k="County" v={p.county || '—'} />
-        <KV k="Containment" v={`${p.containment_pct ?? 0}%`} />
-        <KV k="Acres burned" v={Number(p.acres_burned || 0).toLocaleString()} />
+      <Section t={t} title="Incident">
+        <KV t={t} k="County" v={p.county || '—'} />
+        <KV t={t} k="Containment" v={`${p.containment_pct ?? 0}%`} />
+        <KV t={t} k="Acres burned" v={Number(p.acres_burned || 0).toLocaleString()} />
         {p.spread_rate_km2_per_hr ? (
-          <KV k="Spread rate" v={`${p.spread_rate_km2_per_hr} km²/hr`} />
+          <KV t={t} k="Spread rate" v={`${p.spread_rate_km2_per_hr} km²/hr`} />
         ) : null}
       </Section>
 
       {data && (
         <>
-          <Section title="AI Advisory">
-            <div style={{ ...badgeStyle, background: tone.color }}>
-              {tone.label} · {(data.confidence * 100).toFixed(0)}%
-            </div>
-            <div style={{ ...gateNoteStyle, borderLeft: `3px solid ${tone.color}` }}>
-              <div style={gateNoteReasonStyle}>{tone.reason}</div>
-              <div style={gateNoteActionStyle}>{tone.action}</div>
-            </div>
-            <p style={{ margin: '10px 0 0', fontSize: 13, lineHeight: 1.5, color: '#222' }}>
+          <Section t={t} title="AI Advisory">
+            <Badge color={tone.color}>{tone.label} · {(data.confidence * 100).toFixed(0)}%</Badge>
+            <GateNote t={t} tone={tone} />
+            <p style={{ margin: '10px 0 0', fontSize: 13, lineHeight: 1.5, color: t.textPrimary }}>
               {data.advisory}
             </p>
           </Section>
 
-          <Section title={`Dispatched resources (${data.dispatched_units.length})`}>
+          <Section t={t} title={`Dispatched resources (${data.dispatched_units.length})`}>
             {data.dispatched_units.map((u) => (
-              <div key={u.station_id} style={unitRowStyle}>
+              <div key={u.station_id} style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                padding: '8px 0', borderTop: `1px solid ${t.borderInset}`,
+              }}>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 13, fontWeight: 600, color: '#111' }}>{u.name}</div>
-                  <div style={{ fontSize: 11, color: '#666' }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: t.textPrimary }}>{u.name}</div>
+                  <div style={{ fontSize: 11, color: t.textMuted }}>
                     {u.units} unit{u.units > 1 ? 's' : ''} · {u.distance_km.toFixed(1)} km · ETA {u.eta_min} min
                   </div>
                 </div>
-                <span style={{ ...statusPillStyle, background: STATUS_TONE[u.status] || '#888' }}>
+                <span style={{
+                  fontSize: 10, fontWeight: 700, letterSpacing: 0.5, color: '#fff',
+                  padding: '3px 7px', borderRadius: 3, textTransform: 'uppercase', whiteSpace: 'nowrap',
+                  background: STATUS_TONE[u.status] || '#888',
+                }}>
                   {u.status}
                 </span>
               </div>
@@ -242,119 +298,65 @@ function DispatcherView({ fire, data }) {
   )
 }
 
-function Section({ title, children }) {
+function Section({ t, title, children }) {
   return (
-    <section style={sectionStyle}>
-      <h3 style={sectionTitleStyle}>{title}</h3>
+    <section style={{ padding: '12px 16px', borderBottom: `1px solid ${t.borderSoft}` }}>
+      <h3 style={{
+        margin: '0 0 8px', fontSize: 11, fontWeight: 700, letterSpacing: 1,
+        color: t.textDim, textTransform: 'uppercase',
+      }}>{title}</h3>
       {children}
     </section>
   )
 }
 
-function KV({ k, v, hint }) {
+function KV({ t, k, v, hint }) {
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, padding: '3px 0' }}>
-      <span style={{ color: '#666' }}>{k}</span>
-      <span style={{ color: '#111', fontWeight: 500 }}>
-        {v}{hint ? <span style={{ color: '#aaa', fontWeight: 400, marginLeft: 6 }}>({hint})</span> : null}
+      <span style={{ color: t.textMuted }}>{k}</span>
+      <span style={{ color: t.textPrimary, fontWeight: 500 }}>
+        {v}{hint ? <span style={{ color: t.textVeryDim, fontWeight: 400, marginLeft: 6 }}>({hint})</span> : null}
       </span>
     </div>
   )
 }
 
-function Tab({ active, onClick, children }) {
+function Badge({ color, children }) {
+  return (
+    <div style={{
+      color: '#fff', padding: '6px 10px', borderRadius: 4,
+      fontSize: 11, fontWeight: 700, letterSpacing: 0.5,
+      display: 'inline-block', marginBottom: 8, background: color,
+    }}>{children}</div>
+  )
+}
+
+function GateNote({ t, tone }) {
+  return (
+    <div style={{
+      background: t.gateNoteBg, padding: '8px 10px', borderRadius: 3,
+      marginBottom: 4, fontSize: 12, lineHeight: 1.45,
+      borderLeft: `3px solid ${tone.color}`,
+    }}>
+      <div style={{ color: t.textPrimary, fontWeight: 600, marginBottom: 3 }}>{tone.reason}</div>
+      <div style={{ color: t.textSecondary }}>{tone.action}</div>
+    </div>
+  )
+}
+
+function Tab({ t, active, onClick, children }) {
   return (
     <button
       onClick={onClick}
       style={{
-        ...tabStyle,
-        color: active ? '#111' : '#888',
-        borderBottom: active ? '2px solid #ff5533' : '2px solid transparent',
+        flex: 1, background: 'transparent', border: 'none',
+        padding: '10px 0', fontSize: 12, fontWeight: 600, letterSpacing: 0.5,
+        textTransform: 'uppercase', cursor: 'pointer',
+        color: active ? t.textPrimary : t.textDim,
+        borderBottom: active ? `2px solid ${t.tabAccent}` : '2px solid transparent',
       }}
     >
       {children}
     </button>
   )
-}
-
-const panelStyle = {
-  position: 'absolute',
-  top: 12,
-  right: 12,
-  bottom: 12,
-  width: 340,
-  background: 'rgba(255, 255, 255, 0.97)',
-  borderRadius: 6,
-  boxShadow: '0 4px 16px rgba(0, 0, 0, 0.25)',
-  overflowY: 'auto',
-  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-  zIndex: 5,
-}
-const headerStyle = {
-  padding: '14px 16px 12px',
-  borderBottom: '1px solid #e5e5e5',
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'flex-start',
-  gap: 8,
-}
-const closeBtnStyle = {
-  background: 'transparent', border: 'none', fontSize: 24, lineHeight: 1,
-  cursor: 'pointer', color: '#666', padding: 0, width: 24, height: 24,
-}
-const tabBarStyle = {
-  display: 'flex', borderBottom: '1px solid #e5e5e5',
-  background: '#fafafa',
-}
-const tabStyle = {
-  flex: 1, background: 'transparent', border: 'none',
-  padding: '10px 0', fontSize: 12, fontWeight: 600, letterSpacing: 0.5,
-  textTransform: 'uppercase', cursor: 'pointer',
-}
-const sectionStyle = { padding: '12px 16px', borderBottom: '1px solid #f0f0f0' }
-const sectionTitleStyle = {
-  margin: '0 0 8px', fontSize: 11, fontWeight: 700, letterSpacing: 1,
-  color: '#888', textTransform: 'uppercase',
-}
-const unitRowStyle = {
-  display: 'flex', alignItems: 'center', gap: 8,
-  padding: '8px 0', borderTop: '1px solid #f5f5f5',
-}
-const badgeStyle = {
-  color: '#fff', padding: '6px 10px', borderRadius: 4,
-  fontSize: 11, fontWeight: 700, letterSpacing: 0.5,
-  display: 'inline-block', marginBottom: 8,
-}
-const statusPillStyle = {
-  fontSize: 10, fontWeight: 700, letterSpacing: 0.5, color: '#fff',
-  padding: '3px 7px', borderRadius: 3, textTransform: 'uppercase', whiteSpace: 'nowrap',
-}
-const emptyChipStyle = {
-  position: 'absolute', top: 12, right: 12, zIndex: 5,
-  background: 'rgba(255, 255, 255, 0.92)', color: '#444',
-  padding: '6px 12px', borderRadius: 999,
-  fontSize: 12, fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-  boxShadow: '0 2px 6px rgba(0, 0, 0, 0.15)',
-  display: 'flex', alignItems: 'center', gap: 6,
-  pointerEvents: 'none',
-}
-const loadingStyle = { padding: '12px 16px', fontSize: 12, color: '#888' }
-const gateNoteStyle = {
-  background: '#fafafa', padding: '8px 10px', borderRadius: 3,
-  marginBottom: 4, fontSize: 12, lineHeight: 1.45,
-}
-const gateNoteReasonStyle = { color: '#222', fontWeight: 600, marginBottom: 3 }
-const gateNoteActionStyle = { color: '#555' }
-const evacBoxStyle = {
-  background: '#f5f9ff', border: '1px solid #d6e6ff',
-  padding: '10px 12px', borderRadius: 4,
-}
-const alertMetaStyle = { marginTop: 8 }
-const auditChipStyle = {
-  marginTop: 10, fontSize: 11, color: '#0e8a4e',
-  fontFamily: 'ui-monospace, Menlo, monospace',
-}
-const footerStyle = {
-  padding: '10px 16px', fontSize: 10, color: '#aaa',
-  textAlign: 'center', letterSpacing: 0.3,
 }

--- a/frontend/src/DispatchPanel.jsx
+++ b/frontend/src/DispatchPanel.jsx
@@ -1,5 +1,177 @@
-// Issue #28 — Dispatch panel with Bedrock advisory + SafetyBadge
-// See .claude/agents/frontend-agent.md
-export default function DispatchPanel() {
-  return <div>DispatchPanel — implement in issue #28</div>
+import { useEffect, useState } from 'react'
+import { fetchDispatchData } from './api/dispatch'
+
+// Confidence badge color follows the CLAUDE.md safety contract: <0.65 routes
+// to human review (red), 0.65-0.85 is auto-dispatch but flagged (amber), and
+// ≥0.85 is high-confidence auto-dispatch (green).
+function confidenceTone(score) {
+  if (score < 0.65) return { color: '#ff3322', label: 'HUMAN REVIEW REQUIRED' }
+  if (score < 0.85) return { color: '#ffaa00', label: 'AUTO-DISPATCH (FLAGGED)' }
+  return { color: '#22cc44', label: 'AUTO-DISPATCH' }
+}
+
+const STATUS_TONE = {
+  'en route': '#22cc44',
+  dispatched: '#ffaa00',
+  staged: '#888',
+}
+
+export default function DispatchPanel({ fire, onClose }) {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!fire) {
+      setData(null)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    fetchDispatchData(fire)
+      .then((d) => { if (!cancelled) setData(d) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [fire?.properties?.fire_id])
+
+  if (!fire) {
+    return (
+      <aside style={panelStyle}>
+        <div style={emptyStyle}>
+          <div style={{ fontSize: 32, marginBottom: 8 }}>📍</div>
+          <div>Click a fire on the map to see dispatch details.</div>
+        </div>
+      </aside>
+    )
+  }
+
+  const p = fire.properties
+  const tone = data ? confidenceTone(data.confidence) : null
+
+  return (
+    <aside style={panelStyle}>
+      <header style={headerStyle}>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontSize: 11, opacity: 0.6, letterSpacing: 1 }}>DISPATCH PANEL</div>
+          <h2 style={{ margin: '4px 0 0', fontSize: 18, color: '#111' }}>{p.name}</h2>
+          {p.location && <div style={{ fontSize: 12, color: '#555' }}>{p.location}</div>}
+        </div>
+        <button onClick={onClose} style={closeBtnStyle} aria-label="Close panel">×</button>
+      </header>
+
+      <Section title="Incident">
+        <KV k="County" v={p.county || '—'} />
+        <KV k="Containment" v={`${p.containment_pct ?? 0}%`} />
+        <KV k="Acres burned" v={Number(p.acres_burned || 0).toLocaleString()} />
+        {p.spread_rate_km2_per_hr ? (
+          <KV k="Spread rate" v={`${p.spread_rate_km2_per_hr} km²/hr`} />
+        ) : null}
+      </Section>
+
+      {loading && <div style={loadingStyle}>Loading dispatch data…</div>}
+
+      {data && (
+        <>
+          <Section title="AI Advisory">
+            <div style={{ ...badgeStyle, background: tone.color }}>
+              {tone.label} · {(data.confidence * 100).toFixed(0)}%
+            </div>
+            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5, color: '#222' }}>
+              {data.advisory}
+            </p>
+          </Section>
+
+          <Section title={`Dispatched resources (${data.dispatched_units.length})`}>
+            {data.dispatched_units.map((u) => (
+              <div key={u.station_id} style={unitRowStyle}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: '#111' }}>{u.name}</div>
+                  <div style={{ fontSize: 11, color: '#666' }}>
+                    {u.units} unit{u.units > 1 ? 's' : ''} · {u.distance_km.toFixed(1)} km · ETA {u.eta_min} min
+                  </div>
+                </div>
+                <span style={{ ...statusPillStyle, background: STATUS_TONE[u.status] || '#888' }}>
+                  {u.status}
+                </span>
+              </div>
+            ))}
+          </Section>
+        </>
+      )}
+
+      <footer style={footerStyle}>
+        Stub data — wire to DynamoDB + WebSocket in #30
+      </footer>
+    </aside>
+  )
+}
+
+function Section({ title, children }) {
+  return (
+    <section style={sectionStyle}>
+      <h3 style={sectionTitleStyle}>{title}</h3>
+      {children}
+    </section>
+  )
+}
+
+function KV({ k, v }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, padding: '3px 0' }}>
+      <span style={{ color: '#666' }}>{k}</span>
+      <span style={{ color: '#111', fontWeight: 500 }}>{v}</span>
+    </div>
+  )
+}
+
+const panelStyle = {
+  position: 'absolute',
+  top: 12,
+  right: 12,
+  bottom: 12,
+  width: 340,
+  background: 'rgba(255, 255, 255, 0.97)',
+  borderRadius: 6,
+  boxShadow: '0 4px 16px rgba(0, 0, 0, 0.25)',
+  overflowY: 'auto',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  zIndex: 5,
+}
+const headerStyle = {
+  padding: '14px 16px 12px',
+  borderBottom: '1px solid #e5e5e5',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-start',
+  gap: 8,
+}
+const closeBtnStyle = {
+  background: 'transparent', border: 'none', fontSize: 24, lineHeight: 1,
+  cursor: 'pointer', color: '#666', padding: 0, width: 24, height: 24,
+}
+const sectionStyle = { padding: '12px 16px', borderBottom: '1px solid #f0f0f0' }
+const sectionTitleStyle = {
+  margin: '0 0 8px', fontSize: 11, fontWeight: 700, letterSpacing: 1,
+  color: '#888', textTransform: 'uppercase',
+}
+const unitRowStyle = {
+  display: 'flex', alignItems: 'center', gap: 8,
+  padding: '8px 0', borderTop: '1px solid #f5f5f5',
+}
+const badgeStyle = {
+  color: '#fff', padding: '6px 10px', borderRadius: 4,
+  fontSize: 11, fontWeight: 700, letterSpacing: 0.5,
+  display: 'inline-block', marginBottom: 8,
+}
+const statusPillStyle = {
+  fontSize: 10, fontWeight: 700, letterSpacing: 0.5, color: '#fff',
+  padding: '3px 7px', borderRadius: 3, textTransform: 'uppercase', whiteSpace: 'nowrap',
+}
+const emptyStyle = {
+  padding: 24, textAlign: 'center', color: '#666',
+  fontSize: 13, marginTop: 60,
+}
+const loadingStyle = { padding: '12px 16px', fontSize: 12, color: '#888' }
+const footerStyle = {
+  padding: '10px 16px', fontSize: 10, color: '#aaa',
+  textAlign: 'center', letterSpacing: 0.3,
 }

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -434,20 +434,27 @@ export default function FireMap({ selectedFire, onSelectFire }) {
       <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
       <button
         onClick={() => setTheme((t) => (t === 'light' ? 'dark' : 'light'))}
+        aria-label={theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
+        title={theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
         style={{
-          position: 'absolute', top: 12, right: 12, padding: '8px 12px',
+          position: 'absolute', top: 12, left: 12, width: 36, height: 36,
           background: theme === 'light' ? '#1a1a1a' : '#f5f5f5',
           color: theme === 'light' ? '#f5f5f5' : '#1a1a1a',
-          border: 'none', borderRadius: 4, cursor: 'pointer',
-          fontFamily: 'monospace', fontSize: 13, fontWeight: 600,
-          boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+          border: 'none', borderRadius: '50%', cursor: 'pointer',
+          padding: 0,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          boxShadow: '0 2px 6px rgba(0,0,0,0.25)',
+          transition: 'transform 0.25s ease',
+          zIndex: 6,
         }}
+        onMouseEnter={(e) => (e.currentTarget.style.transform = 'rotate(20deg)')}
+        onMouseLeave={(e) => (e.currentTarget.style.transform = 'rotate(0)')}
       >
-        {theme === 'light' ? 'Dark' : 'Light'}
+        {theme === 'light' ? <MoonIcon /> : <SunIcon />}
       </button>
       {error && (
         <div style={{
-          position: 'absolute', top: 12, left: 12, padding: '8px 12px',
+          position: 'absolute', top: 12, left: 60, padding: '8px 12px',
           background: 'rgba(180, 30, 30, 0.9)', color: '#fff', borderRadius: 4,
           fontFamily: 'monospace', fontSize: 13,
         }}>
@@ -455,5 +462,25 @@ export default function FireMap({ selectedFire, onSelectFire }) {
         </div>
       )}
     </div>
+  )
+}
+
+function SunIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"
+      aria-hidden="true">
+      <path d="M20.5 14.3a8 8 0 1 1-10.8-10.8 8 8 0 0 0 10.8 10.8z" />
+    </svg>
   )
 }

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -26,7 +26,7 @@ const STYLES = {
   dark: 'mapbox://styles/mapbox/dark-v11',
 }
 
-export default function FireMap() {
+export default function FireMap({ selectedFire, onSelectFire }) {
   const containerRef = useRef(null)
   const mapRef = useRef(null)
   const stationsRef = useRef(null)
@@ -37,9 +37,10 @@ export default function FireMap() {
   const didInitTheme = useRef(false)
   const [error, setError] = useState(null)
   const [theme, setTheme] = useState('light')
-  // Click a fire to toggle its evac route. Single-select keeps the map readable
-  // (a dozen overlapping routes turns into spaghetti). null = no route shown.
-  const [selectedFireId, setSelectedFireId] = useState(null)
+  // Selection is lifted to App so the dispatch panel can read it. We derive
+  // the id locally for the evac filter; click handlers report the full feature
+  // back up via onSelectFire.
+  const selectedFireId = selectedFire?.properties?.fire_id ?? null
   const selectedFireIdRef = useRef(null)
   selectedFireIdRef.current = selectedFireId
 
@@ -372,14 +373,19 @@ export default function FireMap() {
     // Click a fire footprint to toggle its evac route. Click again on the same
     // fire (or any empty space) to hide it. Single-fire selection only.
     map.on('click', 'fires-fill', (e) => {
-      const id = e.features[0]?.properties?.fire_id
-      if (!id) return
+      const f = e.features[0]
+      if (!f?.properties?.fire_id) return
       e.originalEvent.__fireClick = true   // suppress the empty-space deselect below
-      setSelectedFireId((prev) => (prev === id ? null : id))
+      // queryRenderedFeatures returns a flat clone — find the matching feature
+      // in firesRef so the panel gets the full property bag (centroid, etc.)
+      const full = firesRef.current?.features?.find(
+        (x) => x.properties.fire_id === f.properties.fire_id,
+      ) || f
+      onSelectFire((prev) => (prev?.properties?.fire_id === full.properties.fire_id ? null : full))
     })
     map.on('click', (e) => {
       if (e.originalEvent.__fireClick) return
-      setSelectedFireId(null)
+      onSelectFire(null)
     })
 
     return () => {

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -26,7 +26,7 @@ const STYLES = {
   dark: 'mapbox://styles/mapbox/dark-v11',
 }
 
-export default function FireMap({ selectedFire, onSelectFire }) {
+export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChange }) {
   const containerRef = useRef(null)
   const mapRef = useRef(null)
   const stationsRef = useRef(null)
@@ -36,7 +36,9 @@ export default function FireMap({ selectedFire, onSelectFire }) {
   const destsRef = useRef(null)
   const didInitTheme = useRef(false)
   const [error, setError] = useState(null)
-  const [theme, setTheme] = useState('light')
+  const setTheme = (next) => {
+    onThemeChange((prev) => (typeof next === 'function' ? next(prev) : next))
+  }
   // Selection is lifted to App so the dispatch panel can read it. We derive
   // the id locally for the evac filter; click handlers report the full feature
   // back up via onSelectFire.

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -1,7 +1,8 @@
 import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { useEffect, useRef, useState } from 'react'
-import { fetchActiveFires } from './api/fires'
+import { fetchActiveFires, buildAlertZones } from './api/fires'
+import { buildEvacRoutes, routeSummaryForFire } from './api/evacRoutes'
 
 mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN
 
@@ -30,9 +31,22 @@ export default function FireMap() {
   const mapRef = useRef(null)
   const stationsRef = useRef(null)
   const firesRef = useRef(null)
+  const zonesRef = useRef(null)
+  const routesRef = useRef(null)
+  const destsRef = useRef(null)
   const didInitTheme = useRef(false)
   const [error, setError] = useState(null)
   const [theme, setTheme] = useState('light')
+  // Click a fire to toggle its evac route. Single-select keeps the map readable
+  // (a dozen overlapping routes turns into spaghetti). null = no route shown.
+  const [selectedFireId, setSelectedFireId] = useState(null)
+  const selectedFireIdRef = useRef(null)
+  selectedFireIdRef.current = selectedFireId
+
+  // Mapbox filter expression that matches a single fire_id (or matches nothing
+  // when null is passed). Used to scope evac route + destination visibility.
+  const filterForSelected = (id) =>
+    id ? ['==', ['get', 'fire_id'], id] : ['==', ['get', 'fire_id'], '__none__']
 
   // Adds the stations source + circle layer. Called on first load and after
   // every setStyle() — changing the basemap wipes user-added sources/layers.
@@ -92,15 +106,151 @@ export default function FireMap() {
     }, 'fire-stations-circle')
   }
 
+  // Alert-zone fill + dashed outline drawn UNDER the fire footprint so the
+  // smaller burned area stays readable on top. Stable amber so it reads as
+  // "warning halo" regardless of containment color.
+  const addAlertZonesLayer = (map, data) => {
+    for (const id of ['alert-zones-fill', 'alert-zones-outline']) {
+      if (map.getLayer(id)) map.removeLayer(id)
+    }
+    if (map.getSource('alert-zones')) map.removeSource('alert-zones')
+
+    map.addSource('alert-zones', { type: 'geojson', data })
+    // Insert beneath fires-fill so the burned footprint sits visibly on top.
+    const beforeId = map.getLayer('fires-fill') ? 'fires-fill' : 'fire-stations-circle'
+    map.addLayer({
+      id: 'alert-zones-fill',
+      type: 'fill',
+      source: 'alert-zones',
+      paint: { 'fill-color': '#ffaa00', 'fill-opacity': 0.12 },
+    }, beforeId)
+    map.addLayer({
+      id: 'alert-zones-outline',
+      type: 'line',
+      source: 'alert-zones',
+      paint: {
+        'line-color': '#ff7700',
+        'line-width': 1.5,
+        'line-opacity': 0.7,
+        'line-dasharray': [2, 2],
+      },
+    }, beforeId)
+  }
+
+  // Evac route polylines drawn ABOVE the alert-zone halo so the corridor reads
+  // clearly, but BELOW stations so trucks stay clickable. Two stacked line
+  // layers (dark casing + bright fill) give a road-style appearance that
+  // contrasts against both light and dark basemaps.
+  const addEvacLayers = (map, routes, destinations) => {
+    for (const id of ['evac-route-casing', 'evac-route-line', 'evac-dest-circle', 'evac-dest-label']) {
+      if (map.getLayer(id)) map.removeLayer(id)
+    }
+    for (const id of ['evac-routes', 'evac-destinations']) {
+      if (map.getSource(id)) map.removeSource(id)
+    }
+
+    map.addSource('evac-routes', { type: 'geojson', data: routes })
+    map.addSource('evac-destinations', { type: 'geojson', data: destinations })
+
+    const beforeId = map.getLayer('fire-stations-circle') ? 'fire-stations-circle' : undefined
+    // All four evac layers honor the same per-fire filter so showing or hiding
+    // a route is a single-state toggle, not four parallel updates.
+    const filter = filterForSelected(selectedFireIdRef.current)
+    map.addLayer({
+      id: 'evac-route-casing',
+      type: 'line',
+      source: 'evac-routes',
+      filter,
+      layout: { 'line-cap': 'round', 'line-join': 'round' },
+      paint: { 'line-color': '#0a3d62', 'line-width': 6, 'line-opacity': 0.9 },
+    }, beforeId)
+    // Line color reflects worst-case traffic on the route. Cyan = clear,
+    // amber/red telegraph "this evac corridor is already congested."
+    map.addLayer({
+      id: 'evac-route-line',
+      type: 'line',
+      source: 'evac-routes',
+      filter,
+      layout: { 'line-cap': 'round', 'line-join': 'round' },
+      paint: {
+        'line-width': 3,
+        'line-opacity': 0.95,
+        'line-color': [
+          'match', ['get', 'traffic_severity'],
+          'severe', '#ff2200',
+          'heavy', '#ff8800',
+          'moderate', '#ffdd33',
+          /* low / unknown */ '#00d2ff',
+        ],
+      },
+    }, beforeId)
+    map.addLayer({
+      id: 'evac-dest-circle',
+      type: 'circle',
+      source: 'evac-destinations',
+      filter,
+      paint: {
+        'circle-radius': 8,
+        'circle-color': '#22cc44',
+        'circle-stroke-color': '#ffffff',
+        'circle-stroke-width': 2,
+      },
+    }, beforeId)
+    map.addLayer({
+      id: 'evac-dest-label',
+      type: 'symbol',
+      source: 'evac-destinations',
+      filter,
+      layout: {
+        'text-field': ['get', 'name'],
+        'text-size': 12,
+        'text-offset': [0, 1.4],
+        'text-anchor': 'top',
+        'text-allow-overlap': false,
+      },
+      paint: {
+        'text-color': '#0a3d62',
+        'text-halo-color': '#ffffff',
+        'text-halo-width': 2,
+      },
+    })
+  }
+
   const refreshFires = async (map) => {
     try {
-      const data = await fetchActiveFires()
-      firesRef.current = data
+      const fires = await fetchActiveFires()
+      const zones = buildAlertZones(fires)
+      firesRef.current = fires
+      zonesRef.current = zones
       if (map.isStyleLoaded()) {
-        const src = map.getSource('active-fires')
-        if (src) src.setData(data)
-        else addFiresLayer(map, data)
+        const fireSrc = map.getSource('active-fires')
+        if (fireSrc) fireSrc.setData(fires)
+        else addFiresLayer(map, fires)
+        const zoneSrc = map.getSource('alert-zones')
+        if (zoneSrc) zoneSrc.setData(zones)
+        else addAlertZonesLayer(map, zones)
       }
+
+      // Evac routes are async per fire and shouldn't block the fires render.
+      // Fire-and-forget; layer updates as soon as routes resolve.
+      buildEvacRoutes(fires).then(({ routes, destinations }) => {
+        routesRef.current = routes
+        destsRef.current = destinations
+        console.log(`[evac] ${routes.features.length}/${fires.features.length} routes resolved`)
+        const apply = () => {
+          const rSrc = map.getSource('evac-routes')
+          const dSrc = map.getSource('evac-destinations')
+          if (rSrc && dSrc) {
+            rSrc.setData(routes)
+            dSrc.setData(destinations)
+          } else {
+            addEvacLayers(map, routes, destinations)
+          }
+        }
+        // Style may still be settling on first load — defer until idle if so.
+        if (map.isStyleLoaded()) apply()
+        else map.once('idle', apply)
+      }).catch((e) => console.warn('evac routes failed:', e.message))
     } catch (e) {
       setError(`fire load failed: ${e.message}`)
     }
@@ -181,12 +331,76 @@ export default function FireMap() {
       map.on('mouseleave', layer, hideFirePopup)
     }
 
+    // Alert-zone popup — population at risk + nearest evac route. These are
+    // client-side stubs today (api/fires.js) and will be replaced by #9's
+    // enrichment + Location Service routing once that pipeline lands.
+    const zonePopup = new mapboxgl.Popup({ closeButton: false, offset: 8 })
+    map.on('mouseenter', 'alert-zones-fill', (e) => {
+      const fireHit = map.queryRenderedFeatures(e.point, { layers: ['fires-fill'] })
+      if (fireHit.length) return  // fire popup wins when hovering the burned area
+      map.getCanvas().style.cursor = 'pointer'
+      const p = e.features[0].properties
+      const route = routeSummaryForFire(p.fire_id)
+      const trafficLabel = {
+        severe: '🔴 severe traffic',
+        heavy: '🟠 heavy traffic',
+        moderate: '🟡 moderate traffic',
+        low: '🟢 clear',
+        unknown: 'traffic unknown',
+      }[route?.traffic_severity] || ''
+      const evacLine = route
+        ? `Evac route: <strong>${route.destination}</strong> — ` +
+          `${route.distance_km.toFixed(0)} km · ${Math.round(route.duration_min)} min<br/>` +
+          `<span style="color:#444;font-size:12px">${trafficLabel} (live)</span>`
+        : `Evac route: ${p.evacuation_route} (computing…)`
+      zonePopup
+        .setLngLat(e.lngLat)
+        .setHTML(
+          `<strong>Alert zone — ${p.name || 'fire'}</strong><br/>` +
+          `Radius: ${Number(p.alert_radius_km).toFixed(1)} km<br/>` +
+          `Population at risk: ~${Number(p.population_at_risk).toLocaleString()}<br/>` +
+          `${evacLine}<br/>` +
+          `<span style="color:#666;font-size:11px">Stub data — #9 enrichment pending</span>`
+        )
+        .addTo(map)
+    })
+    map.on('mouseleave', 'alert-zones-fill', () => {
+      map.getCanvas().style.cursor = ''
+      zonePopup.remove()
+    })
+
+    // Click a fire footprint to toggle its evac route. Click again on the same
+    // fire (or any empty space) to hide it. Single-fire selection only.
+    map.on('click', 'fires-fill', (e) => {
+      const id = e.features[0]?.properties?.fire_id
+      if (!id) return
+      e.originalEvent.__fireClick = true   // suppress the empty-space deselect below
+      setSelectedFireId((prev) => (prev === id ? null : id))
+    })
+    map.on('click', (e) => {
+      if (e.originalEvent.__fireClick) return
+      setSelectedFireId(null)
+    })
+
     return () => {
       clearInterval(interval)
       map.remove()
       mapRef.current = null
     }
   }, [])
+
+  // Push the per-fire selection into the four evac layer filters whenever the
+  // user clicks a different fire. Layers may not exist yet on first selection
+  // (routes haven't resolved) — addEvacLayers reads the same ref to apply the
+  // current filter at creation time.
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map) return
+    const filter = filterForSelected(selectedFireId)
+    for (const id of ['evac-route-casing', 'evac-route-line', 'evac-dest-circle', 'evac-dest-label']) {
+      if (map.getLayer(id)) map.setFilter(id, filter)
+    }
+  }, [selectedFireId])
 
   // Swap basemap on theme change; re-attach stations once the new style settles.
   // Skip the first run — the map constructor already loaded the initial theme.
@@ -202,6 +416,10 @@ export default function FireMap() {
     map.once('style.load', () => {
       if (stationsRef.current) addStationsLayer(map, stationsRef.current)
       if (firesRef.current) addFiresLayer(map, firesRef.current)
+      if (zonesRef.current) addAlertZonesLayer(map, zonesRef.current)
+      if (routesRef.current && destsRef.current) {
+        addEvacLayers(map, routesRef.current, destsRef.current)
+      }
     })
   }, [theme])
 

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -456,7 +456,7 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
       </button>
       {error && (
         <div style={{
-          position: 'absolute', top: 12, left: 60, padding: '8px 12px',
+          position: 'absolute', top: 56, left: 12, padding: '8px 12px',
           background: 'rgba(180, 30, 30, 0.9)', color: '#fff', borderRadius: 4,
           fontFamily: 'monospace', fontSize: 13,
         }}>

--- a/frontend/src/RegisterModal.jsx
+++ b/frontend/src/RegisterModal.jsx
@@ -1,0 +1,271 @@
+import { useEffect, useState } from 'react'
+import { geocodeAddress, registerResident, validateRegistration } from './api/residents'
+
+// Resident SMS-alert registration. Modal-based so it overlays the map without
+// dragging React Router into the bundle for a single screen.
+//
+// Submission flow: validate → geocode address → POST to register stub. The
+// geocode happens client-side via Mapbox so the backend doesn't need to call
+// Location Service for users on a map already showing Mapbox tiles.
+
+function tokens(theme) {
+  const dark = theme === 'dark'
+  return {
+    overlayBg: 'rgba(0, 0, 0, 0.55)',
+    panelBg: dark ? '#1c1c1f' : '#ffffff',
+    panelBorder: dark ? '#2a2a2d' : '#e5e5e5',
+    textPrimary: dark ? '#f1f1f3' : '#111',
+    textSecondary: dark ? '#bdbdc2' : '#555',
+    textMuted: dark ? '#9a9aa0' : '#666',
+    textDim: dark ? '#86868c' : '#888',
+    inputBg: dark ? '#26262a' : '#fff',
+    inputBorder: dark ? '#3a3a3f' : '#d0d0d0',
+    inputBorderFocus: '#ff5533',
+    accent: '#ff5533',
+    accentText: '#fff',
+    successBg: dark ? '#143822' : '#e6f7ee',
+    successText: dark ? '#7be0a3' : '#0e6b3a',
+    errorText: '#ff5544',
+    eyebrow: dark ? '#cfcfd4' : '#444',
+  }
+}
+
+const initialForm = {
+  name: '',
+  phone: '',
+  address: '',
+  alert_radius_km: 10,
+}
+
+export default function RegisterModal({ open, onClose, theme = 'light' }) {
+  const t = tokens(theme)
+  const [form, setForm] = useState(initialForm)
+  const [errors, setErrors] = useState({})
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState(null)
+  const [confirmation, setConfirmation] = useState(null)
+
+  // Reset on open so a re-opened modal starts clean. Don't reset on close —
+  // the closing animation would briefly flash the empty form.
+  useEffect(() => {
+    if (open) {
+      setForm(initialForm)
+      setErrors({})
+      setSubmitError(null)
+      setConfirmation(null)
+    }
+  }, [open])
+
+  // Esc closes — standard modal expectation, and the onClick overlay close
+  // alone is a trap for keyboard users.
+  useEffect(() => {
+    if (!open) return
+    const handler = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const update = (k) => (e) => setForm((f) => ({ ...f, [k]: e.target.value }))
+
+  const submit = async (e) => {
+    e.preventDefault()
+    setSubmitError(null)
+    const phone = form.phone.trim()
+    const address = form.address.trim()
+    const alertRadius = Number(form.alert_radius_km)
+
+    const errs = validateRegistration({ phone, address, alert_radius_km: alertRadius })
+    if (Object.keys(errs).length) {
+      setErrors(errs)
+      return
+    }
+    setErrors({})
+    setSubmitting(true)
+
+    try {
+      const geo = await geocodeAddress(address)
+      const result = await registerResident({
+        phone,
+        lat: geo.lat,
+        lon: geo.lon,
+        alert_radius_km: alertRadius,
+      })
+      setConfirmation({
+        radius_km: result.alert_radius_km,
+        place: geo.place_name,
+      })
+    } catch (err) {
+      setSubmitError(err.message || 'Registration failed.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: t.overlayBg,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 50, padding: 16,
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="register-title"
+        style={{
+          background: t.panelBg, color: t.textPrimary,
+          width: '100%', maxWidth: 420, borderRadius: 8,
+          border: `1px solid ${t.panelBorder}`,
+          boxShadow: '0 12px 40px rgba(0, 0, 0, 0.45)',
+          overflow: 'hidden',
+        }}
+      >
+        <header style={{
+          padding: '18px 20px 14px', borderBottom: `1px solid ${t.panelBorder}`,
+          display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8,
+        }}>
+          <div>
+            <div style={{ fontSize: 11, color: t.eyebrow, letterSpacing: 1, fontWeight: 600 }}>
+              SMS ALERT SIGN-UP
+            </div>
+            <h2 id="register-title" style={{ margin: '4px 0 0', fontSize: 18 }}>
+              Get notified when fire threatens your area
+            </h2>
+          </div>
+          <button onClick={onClose} aria-label="Close" style={{
+            background: 'transparent', border: 'none', fontSize: 24, lineHeight: 1,
+            cursor: 'pointer', color: t.textMuted, padding: 0, width: 24, height: 24,
+          }}>×</button>
+        </header>
+
+        {confirmation ? (
+          <div style={{ padding: 20 }}>
+            <div style={{
+              background: t.successBg, color: t.successText,
+              padding: '12px 14px', borderRadius: 6, fontSize: 13, lineHeight: 1.5,
+            }}>
+              <div style={{ fontWeight: 700, marginBottom: 4 }}>You're registered.</div>
+              You'll receive SMS alerts for fires within{' '}
+              <strong>{confirmation.radius_km} km</strong> of{' '}
+              <strong>{confirmation.place}</strong>.
+            </div>
+            <div style={{ marginTop: 14, fontSize: 12, color: t.textSecondary, lineHeight: 1.5 }}>
+              We never share your number. SMS only goes out when a fire passes our
+              safety gate (Bedrock Guardrails + ≥65% confidence).
+            </div>
+            <button onClick={onClose} style={{
+              marginTop: 16, width: '100%', padding: '10px 14px',
+              background: t.accent, color: t.accentText, border: 'none',
+              borderRadius: 5, fontSize: 14, fontWeight: 600, cursor: 'pointer',
+            }}>
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={submit} style={{ padding: 20, display: 'grid', gap: 14 }}>
+            <Field label="Name (optional)" t={t}>
+              <input
+                value={form.name}
+                onChange={update('name')}
+                style={inputStyle(t)}
+                placeholder="Jane Doe"
+                autoComplete="name"
+              />
+            </Field>
+
+            <Field label="Phone number" t={t} error={errors.phone}>
+              <input
+                value={form.phone}
+                onChange={update('phone')}
+                style={inputStyle(t, !!errors.phone)}
+                placeholder="+15551234567"
+                inputMode="tel"
+                autoComplete="tel"
+                required
+              />
+              <Hint t={t}>Include country code (E.164 format).</Hint>
+            </Field>
+
+            <Field label="Home address" t={t} error={errors.address}>
+              <input
+                value={form.address}
+                onChange={update('address')}
+                style={inputStyle(t, !!errors.address)}
+                placeholder="123 Main St, San Francisco, CA"
+                autoComplete="street-address"
+                required
+              />
+              <Hint t={t}>Used to check whether your area is in a fire's alert radius.</Hint>
+            </Field>
+
+            <Field label="Alert radius" t={t} error={errors.alert_radius_km}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <input
+                  type="range" min={1} max={50} step={1}
+                  value={form.alert_radius_km}
+                  onChange={update('alert_radius_km')}
+                  style={{ flex: 1, accentColor: t.accent }}
+                />
+                <span style={{
+                  minWidth: 56, textAlign: 'right',
+                  fontVariantNumeric: 'tabular-nums', fontWeight: 600, fontSize: 13,
+                }}>
+                  {form.alert_radius_km} km
+                </span>
+              </div>
+              <Hint t={t}>You'll be notified for fires whose alert zone overlaps this radius.</Hint>
+            </Field>
+
+            {submitError && (
+              <div style={{ color: t.errorText, fontSize: 13 }}>{submitError}</div>
+            )}
+
+            <button type="submit" disabled={submitting} style={{
+              padding: '11px 14px',
+              background: submitting ? t.textDim : t.accent,
+              color: t.accentText, border: 'none',
+              borderRadius: 5, fontSize: 14, fontWeight: 600,
+              cursor: submitting ? 'wait' : 'pointer',
+            }}>
+              {submitting ? 'Registering…' : 'Sign up for alerts'}
+            </button>
+
+            <div style={{ fontSize: 11, color: t.textDim, textAlign: 'center' }}>
+              Stub — real Cognito + DynamoDB wiring lands in #30.
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, t, error, children }) {
+  return (
+    <label style={{ display: 'grid', gap: 5, fontSize: 12 }}>
+      <span style={{ color: t.textSecondary, fontWeight: 600, letterSpacing: 0.3 }}>{label}</span>
+      {children}
+      {error && <span style={{ color: '#ff5544', fontSize: 12 }}>{error}</span>}
+    </label>
+  )
+}
+
+function Hint({ t, children }) {
+  return <span style={{ color: t.textDim, fontSize: 11 }}>{children}</span>
+}
+
+function inputStyle(t, hasError = false) {
+  return {
+    background: t.inputBg, color: t.textPrimary,
+    border: `1px solid ${hasError ? '#ff5544' : t.inputBorder}`,
+    borderRadius: 5, padding: '9px 11px', fontSize: 14,
+    outline: 'none', width: '100%', boxSizing: 'border-box',
+    fontFamily: 'inherit',
+  }
+}

--- a/frontend/src/api/dispatch.js
+++ b/frontend/src/api/dispatch.js
@@ -1,0 +1,131 @@
+// Dispatch + advisory data — STUBBED.
+//
+// In the shipped pipeline this comes from DynamoDB (resources table written by
+// #22 alert sender) and the safety-gated Bedrock advisory (#21). Until #30
+// wires the API Gateway + WebSocket, the panel reads from this generator,
+// which produces deterministic, fire-specific stubs from the live fire props
+// and the static fire-stations GeoJSON.
+
+const STATIONS_URL = '/data/fire_stations.geojson'
+const EARTH_RADIUS_KM = 6371
+
+let stationsCache = null
+async function loadStations() {
+  if (stationsCache) return stationsCache
+  const res = await fetch(STATIONS_URL, { cache: 'force-cache' })
+  if (!res.ok) throw new Error(`stations fetch ${res.status}`)
+  stationsCache = await res.json()
+  return stationsCache
+}
+
+function haversineKm(a, b) {
+  const toRad = (d) => (d * Math.PI) / 180
+  const dLat = toRad(b[1] - a[1])
+  const dLon = toRad(b[0] - a[0])
+  const lat1 = toRad(a[1])
+  const lat2 = toRad(b[1])
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h))
+}
+
+// Deterministic hash → 0..1, so the same fire always produces the same stubs.
+// Avoids dispatched units flickering between renders.
+function hash01(str) {
+  let h = 2166136261
+  for (let i = 0; i < str.length; i++) h = Math.imul(h ^ str.charCodeAt(i), 16777619)
+  return ((h >>> 0) % 10000) / 10000
+}
+
+// Confidence is weighted by containment (a contained fire is a clearer call
+// for the model) plus a small per-fire jitter. The 0.65 threshold is the
+// CLAUDE.md safety contract — anything below routes to human review.
+function fakeConfidence(fire) {
+  const p = fire.properties || {}
+  const containmentBoost = Math.min(1, (p.containment_pct ?? 0) / 100) * 0.2
+  const jitter = (hash01(p.fire_id || p.name || '') - 0.5) * 0.25
+  return Math.max(0.3, Math.min(0.98, 0.72 + containmentBoost + jitter))
+}
+
+// Templated advisory — three tone tiers so the panel reflects the fire's
+// severity. Real advisories will come from the Bedrock prompt (#14) post-
+// Guardrails (#16) post-safety-gate (#21).
+function fakeAdvisory(fire) {
+  const p = fire.properties || {}
+  const acres = p.acres_burned ?? 0
+  const contained = p.containment_pct ?? 0
+  const name = p.name || 'this incident'
+  if (contained >= 70) {
+    return (
+      `Mop-up phase recommended for ${name}. Maintain perimeter watch with current ` +
+      `engines; release surge units back to home stations. Continue air monitoring ` +
+      `for 24h post-containment.`
+    )
+  }
+  if (acres > 10000 || contained < 20) {
+    return (
+      `EXTREME risk profile for ${name}. Recommend full strike-team mobilization, ` +
+      `pre-position air tankers at the nearest ANG base, and stage shelters in the ` +
+      `downwind alert zone. Coordinate with CHP for highway closures along the evac ` +
+      `corridor.`
+    )
+  }
+  return (
+    `Active suppression for ${name}. Dispatch nearest engine companies and one ` +
+    `Type 1 hand crew. Stage second-wave resources within the alert radius and ` +
+    `prepare evacuation messaging for residents in the threatened zone.`
+  )
+}
+
+// Picks 2-4 nearest stations and assigns deterministic unit counts + ETAs.
+// Status mirrors what the alert sender (#22) would post back to DynamoDB.
+async function fakeDispatchedUnits(fire) {
+  const p = fire.properties || {}
+  const center = p.centroid
+  if (!center) return []
+  const data = await loadStations()
+  const candidates = (data.features || [])
+    .map((s) => ({
+      station_id: s.properties.station_id,
+      name: s.properties.name,
+      county: s.properties.county,
+      available: s.properties.available !== false,
+      distance_km: haversineKm(center, s.geometry.coordinates),
+    }))
+    .sort((a, b) => a.distance_km - b.distance_km)
+
+  // Larger fires pull more stations.
+  const acres = p.acres_burned ?? 0
+  const stationCount = acres > 20000 ? 4 : acres > 5000 ? 3 : 2
+  return candidates.slice(0, stationCount).map((s, i) => {
+    const seed = hash01(`${p.fire_id}-${s.station_id}`)
+    // Average emergency response speed in CA backcountry: ~60 km/h.
+    const etaMin = Math.round((s.distance_km / 60) * 60 + 4 + seed * 6)
+    const units = Math.max(1, Math.round(2 + seed * 3))
+    // Closest unit is en-route; subsequent waves staged.
+    const status = i === 0 ? 'en route' : i === 1 ? 'dispatched' : 'staged'
+    return {
+      station_id: s.station_id,
+      name: s.name,
+      county: s.county,
+      distance_km: s.distance_km,
+      units,
+      eta_min: etaMin,
+      status,
+      available: s.available,
+    }
+  })
+}
+
+// Public entry — returns everything the dispatch panel needs for a given fire.
+// One async call so the panel can show a single loading state.
+export async function fetchDispatchData(fire) {
+  if (!fire) return null
+  const [units] = await Promise.all([fakeDispatchedUnits(fire)])
+  return {
+    fire_id: fire.properties.fire_id,
+    confidence: fakeConfidence(fire),
+    advisory: fakeAdvisory(fire),
+    dispatched_units: units,
+    generated_at: new Date().toISOString(),
+  }
+}

--- a/frontend/src/api/dispatch.js
+++ b/frontend/src/api/dispatch.js
@@ -116,16 +116,46 @@ async function fakeDispatchedUnits(fire) {
   })
 }
 
-// Public entry — returns everything the dispatch panel needs for a given fire.
+// Audit hash chain — each alert gets a deterministic SHA-like fingerprint so
+// residents can see proof the safety gate ran. Real chain is written by the
+// safety-gate Lambda (#21) into the wildfire-watch-audit DynamoDB table; this
+// stub just renders something hash-looking from the fire_id.
+function fakeAuditHash(fire) {
+  const seed = (fire.properties?.fire_id || fire.properties?.name || 'unknown') + '|audit'
+  let h = 2166136261
+  const out = []
+  for (let i = 0; i < 8; i++) {
+    for (let j = 0; j < seed.length; j++) h = Math.imul(h ^ (seed.charCodeAt(j) + i), 16777619)
+    out.push((h >>> 0).toString(16).padStart(8, '0'))
+  }
+  return '0x' + out.join('').slice(0, 40)
+}
+
+// Mock alert-sent timestamp — stable per fire so the UI doesn't flicker.
+// Real timestamp comes from the alert sender (#22) when sns.publish returns.
+function fakeAlertSentAt(fire) {
+  const seed = hash01(fire.properties?.fire_id || '')
+  // Push the timestamp 2-30 minutes into the past so "X min ago" reads well.
+  const minutesAgo = Math.round(2 + seed * 28)
+  return new Date(Date.now() - minutesAgo * 60_000).toISOString()
+}
+
+// Public entry — returns everything both panel views need for a given fire.
 // One async call so the panel can show a single loading state.
 export async function fetchDispatchData(fire) {
   if (!fire) return null
   const [units] = await Promise.all([fakeDispatchedUnits(fire)])
+  const population = fire.properties?.population_at_risk ?? 0
   return {
     fire_id: fire.properties.fire_id,
     confidence: fakeConfidence(fire),
     advisory: fakeAdvisory(fire),
     dispatched_units: units,
+    // Resident-facing fields. Alerts go to ~85-95% of at-risk residents
+    // (the rest haven't registered for SMS yet).
+    alerts_sent: Math.round(population * (0.85 + hash01(fire.properties.fire_id || '') * 0.1)),
+    alert_sent_at: fakeAlertSentAt(fire),
+    audit_hash: fakeAuditHash(fire),
     generated_at: new Date().toISOString(),
   }
 }

--- a/frontend/src/api/evacRoutes.js
+++ b/frontend/src/api/evacRoutes.js
@@ -1,0 +1,179 @@
+// Evacuation route generator.
+//
+// For each active fire we pick a "safe destination" — a major California city
+// far enough from the fire to plausibly be outside the threatened area — and
+// query Mapbox Directions for a road-following route from the fire centroid.
+// Routes are cached by fire_id so polling doesn't re-hit the API every 30s.
+//
+// This is a frontend stand-in for what the dispatcher service will eventually
+// compute server-side once #9's enrichment + Location Service routing land.
+// The data still flows through the same map layer, so swapping the source is
+// a one-line change at fetch time.
+
+import mapboxgl from 'mapbox-gl'
+
+// Major California cities used as evacuation targets. Chosen for population
+// density (real shelters cluster around them) and statewide coverage so any
+// fire has a candidate within reasonable driving distance.
+const SAFE_CITIES = [
+  { name: 'Los Angeles', lon: -118.2437, lat: 34.0522 },
+  { name: 'San Diego', lon: -117.1611, lat: 32.7157 },
+  { name: 'San Francisco', lon: -122.4194, lat: 37.7749 },
+  { name: 'Sacramento', lon: -121.4944, lat: 38.5816 },
+  { name: 'San Jose', lon: -121.8863, lat: 37.3382 },
+  { name: 'Fresno', lon: -119.7871, lat: 36.7378 },
+  { name: 'Long Beach', lon: -118.1937, lat: 33.7701 },
+  { name: 'Bakersfield', lon: -119.0187, lat: 35.3733 },
+  { name: 'Oakland', lon: -122.2712, lat: 37.8044 },
+  { name: 'Santa Barbara', lon: -119.6982, lat: 34.4208 },
+  { name: 'Ventura', lon: -119.2945, lat: 34.2746 },
+  { name: 'Palm Springs', lon: -116.5453, lat: 33.8303 },
+  { name: 'San Luis Obispo', lon: -120.6596, lat: 35.2828 },
+  { name: 'Redding', lon: -122.3917, lat: 40.5865 },
+  { name: 'Eureka', lon: -124.1637, lat: 40.8021 },
+]
+
+const EARTH_RADIUS_KM = 6371
+
+// Haversine — needed both for picking destinations and reporting fire→safe
+// distance in the popup.
+function haversineKm(a, b) {
+  const toRad = (d) => (d * Math.PI) / 180
+  const dLat = toRad(b.lat - a.lat)
+  const dLon = toRad(b.lon - a.lon)
+  const lat1 = toRad(a.lat)
+  const lat2 = toRad(b.lat)
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h))
+}
+
+// Evacuation destination must be:
+//   - outside the fire's alert radius (no point routing into the threat zone)
+//   - at least 25 km away (closer than that and the route is just neighborhood
+//     streets, not an evacuation corridor)
+// Of the candidates that qualify, pick the closest — drives shorter than 50 km
+// are operationally realistic and Mapbox returns them faster.
+const MIN_EVAC_KM = 25
+
+function pickDestination(fire) {
+  const p = fire.properties || {}
+  const center = p.centroid
+  if (!center) return null
+  const fireLatLon = { lon: center[0], lat: center[1] }
+  const minSafeDist = Math.max(MIN_EVAC_KM, (p.alert_radius_km || 0) + 5)
+  const candidates = SAFE_CITIES
+    .map((c) => ({ ...c, dist: haversineKm(fireLatLon, c) }))
+    .filter((c) => c.dist >= minSafeDist)
+    .sort((a, b) => a.dist - b.dist)
+  return candidates[0] || null
+}
+
+// Cache key — fire_id only. Live traffic conditions evolve, so entries expire
+// after 5 minutes. That's frequent enough that durations stay believable but
+// infrequent enough that we're not hammering the Directions API on every poll.
+const routeCache = new Map()
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+// Worst congestion level seen on the route. Mapbox returns one of:
+//   "low" | "moderate" | "heavy" | "severe" | "unknown"
+const CONGESTION_RANK = { unknown: 0, low: 1, moderate: 2, heavy: 3, severe: 4 }
+function worstCongestion(legs) {
+  let worst = 'low'
+  for (const leg of legs || []) {
+    for (const c of leg.annotation?.congestion || []) {
+      if ((CONGESTION_RANK[c] ?? 0) > (CONGESTION_RANK[worst] ?? 0)) worst = c
+    }
+  }
+  return worst
+}
+
+async function fetchOneRoute(fire) {
+  if (!mapboxgl.accessToken) return null
+  const fireId = fire.properties?.fire_id
+  if (!fireId) return null
+  const cached = routeCache.get(fireId)
+  if (cached && Date.now() - cached._cachedAt < CACHE_TTL_MS) return cached
+
+  const dest = pickDestination(fire)
+  if (!dest) return null
+
+  const [lon1, lat1] = fire.properties.centroid
+  // driving-traffic profile uses Mapbox's live traffic data — the route
+  // selection avoids current congestion and the returned duration reflects
+  // real-world travel time, not free-flow.
+  const url =
+    `https://api.mapbox.com/directions/v5/mapbox/driving-traffic/` +
+    `${lon1},${lat1};${dest.lon},${dest.lat}` +
+    `?geometries=geojson&overview=full&annotations=duration,congestion` +
+    `&access_token=${mapboxgl.accessToken}`
+
+  try {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = await res.json()
+    const route = data.routes?.[0]
+    if (!route) return null
+    const result = {
+      type: 'Feature',
+      geometry: route.geometry,
+      _cachedAt: Date.now(),
+      properties: {
+        fire_id: fireId,
+        fire_name: fire.properties.name,
+        destination_name: dest.name,
+        // Mapbox returns metres + seconds. duration_typical_min would be the
+        // free-flow time; duration_min reflects current traffic.
+        distance_km: route.distance / 1000,
+        duration_min: route.duration / 60,
+        traffic_severity: worstCongestion(route.legs),
+        destination_lon: dest.lon,
+        destination_lat: dest.lat,
+      },
+    }
+    routeCache.set(fireId, result)
+    return result
+  } catch (e) {
+    // Routing failures shouldn't break the rest of the map. Cache null briefly
+    // so we don't hammer a failing endpoint, but allow retry on next refresh.
+    console.warn(`evac route fetch failed for ${fireId}:`, e.message)
+    return null
+  }
+}
+
+// Returns one FeatureCollection of route LineStrings + a parallel collection
+// of destination markers. Concurrent fetch with Promise.all — Mapbox's free
+// tier comfortably handles a few dozen parallel directions queries.
+export async function buildEvacRoutes(fireCollection) {
+  const fires = fireCollection?.features || []
+  const results = await Promise.all(fires.map(fetchOneRoute))
+  const routes = results.filter(Boolean)
+  const destinations = routes.map((r) => ({
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [r.properties.destination_lon, r.properties.destination_lat] },
+    properties: {
+      name: r.properties.destination_name,
+      fire_name: r.properties.fire_name,
+      distance_km: r.properties.distance_km,
+      duration_min: r.properties.duration_min,
+    },
+  }))
+  return {
+    routes: { type: 'FeatureCollection', features: routes },
+    destinations: { type: 'FeatureCollection', features: destinations },
+  }
+}
+
+// Returns route metadata for a given fire_id (for popups). Reads from the
+// same cache populated by buildEvacRoutes — no extra network call.
+export function routeSummaryForFire(fireId) {
+  const r = routeCache.get(fireId)
+  if (!r) return null
+  return {
+    destination: r.properties.destination_name,
+    distance_km: r.properties.distance_km,
+    duration_min: r.properties.duration_min,
+    traffic_severity: r.properties.traffic_severity,
+  }
+}

--- a/frontend/src/api/fires.js
+++ b/frontend/src/api/fires.js
@@ -11,9 +11,9 @@
 const ACRES_TO_KM2 = 0.00404686
 const EARTH_RADIUS_KM = 6371
 const CIRCLE_VERTICES = 4
-const MIN_RADIUS_KM = 3      // floor so small fires are visible at statewide zoom
-const VISUAL_SCALE = 4       // exaggerate footprint for demo legibility — a real
-                             // 100-acre fire is ~300m across, invisible at zoom 6
+const MIN_RADIUS_KM = 0.2    // tiny floor so 0-acre fires still render as a dot
+const VISUAL_SCALE = 2       // mild 2x — preserves real ratios between fires
+                             // while making small ones visible at zoom 6
 
 function acresToRadiusKm(acres) {
   const km2 = Math.max(0, acres) * ACRES_TO_KM2
@@ -50,13 +50,42 @@ const CALFIRE_URL = '/api/calfire'   // proxied in vite.config.js to bypass CORS
 
 const USE_MOCK = import.meta.env.VITE_USE_MOCK_FIRES === 'true'
 
+// Stub county → primary evacuation route map. #9's enrichment Lambda + Location
+// Service routing will replace this with real route geometry.
+const EVAC_ROUTES = {
+  'Los Angeles': 'I-5 N → SR-14',
+  'Orange': 'I-5 S → SR-55',
+  'Riverside': 'I-15 N → SR-91',
+  'San Bernardino': 'I-15 S → I-10 W',
+  'San Diego': 'I-8 W → I-5 N',
+  'Ventura': 'US-101 N',
+  'Kern': 'SR-58 W → I-5',
+  'Fresno': 'SR-99 N',
+  'Santa Barbara': 'US-101 S',
+  'Tulare': 'SR-65 → SR-99',
+}
+
+// Population-at-risk stub — proportional to acres with a 250-person floor so
+// even small fires register as a non-zero alert. Real numbers come from #9's
+// US Census enrichment by alert-radius polygon.
+function estimatePopulationAtRisk(acres) {
+  return Math.max(250, Math.round((acres || 0) * 8))
+}
+
+// Alert radius scales sub-linearly with acreage so small and large incidents
+// stay distinguishable: a 200-acre brushfire gets ~5 km, a 75 k-acre megafire
+// gets ~45 km. 3 km floor keeps any active fire visible as an alert zone.
+function alertRadiusKm(acres) {
+  return 3 + Math.sqrt(Math.max(0, acres)) * 0.15
+}
+
 function normalizeCalFireFeature(f) {
   const p = f.properties || {}
   const acres = p.AcresBurned ?? 0
-  const geometry =
-    f.geometry?.type === 'Point'
-      ? circlePolygon(f.geometry.coordinates, acresToRadiusKm(acres))
-      : f.geometry
+  const point = f.geometry?.type === 'Point' ? f.geometry.coordinates : null
+  const geometry = point
+    ? circlePolygon(point, acresToRadiusKm(acres))
+    : f.geometry
   return {
     type: 'Feature',
     geometry,
@@ -64,13 +93,84 @@ function normalizeCalFireFeature(f) {
       fire_id: p.UniqueId,
       name: (p.Name || '').trim(),
       containment_pct: p.PercentContained ?? 0,
-      acres_burned: p.AcresBurned ?? 0,
+      acres_burned: acres,
       county: p.County,
       location: p.Location,
       detected_at: p.Started,
       last_updated: p.Updated,
       url: p.Url,
+      // Populated client-side as a stand-in for #9 enrichment + Location Service.
+      alert_radius_km: alertRadiusKm(acres),
+      population_at_risk: estimatePopulationAtRisk(acres),
+      evacuation_route: EVAC_ROUTES[p.County] || 'Check local CAL FIRE advisory',
+      // Centroid used to draw the alert-zone polygon (see buildAlertZones).
+      centroid: point,
       // spread_rate isn't in the CAL FIRE feed — leave undefined; popup tolerates it
+    },
+  }
+}
+
+// Polygon centroid via average of ring vertices (close enough for our convex
+// synth circles and the small mock diamonds; not a true area-weighted centroid).
+function polygonCentroid(geometry) {
+  const ring = geometry?.coordinates?.[0]
+  if (!ring?.length) return null
+  let sx = 0, sy = 0
+  // Last vertex of a closed ring duplicates the first — skip it.
+  const n = ring.length - 1
+  for (let i = 0; i < n; i++) {
+    sx += ring[i][0]
+    sy += ring[i][1]
+  }
+  return [sx / n, sy / n]
+}
+
+// Derives a FeatureCollection of alert-zone circles from the fire features.
+// Kept as a separate source so the zone fill can sit under the fire footprint
+// without confusing layer stacking or hover targets.
+export function buildAlertZones(fireCollection) {
+  const features = (fireCollection?.features || [])
+    .map((f) => {
+      const p = f.properties || {}
+      const center = p.centroid || polygonCentroid(f.geometry)
+      if (!center) return null
+      const radius = p.alert_radius_km || alertRadiusKm(p.acres_burned)
+      return {
+        type: 'Feature',
+        geometry: circlePolygon(center, radius),
+        properties: {
+          fire_id: p.fire_id,
+          name: p.name,
+          population_at_risk: p.population_at_risk ?? estimatePopulationAtRisk(p.acres_burned),
+          evacuation_route: p.evacuation_route || EVAC_ROUTES[p.county] || 'Check local CAL FIRE advisory',
+          alert_radius_km: radius,
+        },
+      }
+    })
+    .filter(Boolean)
+  return { type: 'FeatureCollection', features }
+}
+
+// Mock fires are stored in our normalized schema as Points + acres_burned, then
+// run through the same synthesis pipeline as live (so alert radius, centroid,
+// stubs, and footprint all derive from the same code path).
+function normalizeMockFeature(f) {
+  const p = f.properties || {}
+  const point = f.geometry?.type === 'Point' ? f.geometry.coordinates : null
+  const acres = p.acres_burned ?? 0
+  const geometry = point
+    ? circlePolygon(point, acresToRadiusKm(acres))
+    : f.geometry
+  return {
+    type: 'Feature',
+    geometry,
+    properties: {
+      ...p,
+      acres_burned: acres,
+      alert_radius_km: alertRadiusKm(acres),
+      population_at_risk: p.population_at_risk ?? estimatePopulationAtRisk(acres),
+      evacuation_route: p.evacuation_route || EVAC_ROUTES[p.county] || 'Check local CAL FIRE advisory',
+      centroid: point || polygonCentroid(f.geometry),
     },
   }
 }
@@ -78,7 +178,11 @@ function normalizeCalFireFeature(f) {
 async function fetchMock() {
   const res = await fetch(MOCK_URL, { cache: 'no-store' })
   if (!res.ok) throw new Error(`failed to fetch mock fires (${res.status})`)
-  return res.json()
+  const raw = await res.json()
+  return {
+    type: 'FeatureCollection',
+    features: (raw.features || []).map(normalizeMockFeature),
+  }
 }
 
 async function fetchLive() {

--- a/frontend/src/api/residents.js
+++ b/frontend/src/api/residents.js
@@ -1,0 +1,70 @@
+// Resident registration — STUBBED.
+//
+// In production this calls POST /residents/register through API Gateway
+// authenticated by Cognito (functions/alert/register.py is the backend).
+// Until #30 wires API Gateway and Cognito, the form posts to this stub
+// which validates the same way the Lambda does and pretends to succeed.
+
+import mapboxgl from 'mapbox-gl'
+
+const E164_RE = /^\+[1-9]\d{1,14}$/
+
+// Mirrors functions/alert/register.py validation so the form catches the
+// same bad input the backend would reject — no point shipping a request
+// the API will 400 anyway.
+export function validateRegistration({ phone, address, lat, lon, alert_radius_km }) {
+  const errors = {}
+  if (!phone) errors.phone = 'Phone number is required.'
+  else if (!E164_RE.test(phone)) errors.phone = 'Use E.164 format (e.g. +15551234567).'
+
+  const hasAddress = address && address.trim().length > 0
+  const hasLatLon = lat != null && lon != null
+  if (!hasAddress && !hasLatLon) errors.address = 'Address (or coordinates) is required.'
+
+  if (alert_radius_km != null) {
+    const r = Number(alert_radius_km)
+    if (!Number.isFinite(r) || r <= 0) errors.alert_radius_km = 'Radius must be a positive number.'
+    else if (r > 100) errors.alert_radius_km = 'Radius must be ≤ 100 km.'
+  }
+  return errors
+}
+
+// Mapbox geocoding — converts a free-form address to lat/lon client-side
+// so we skip the server's Location Service round-trip. California-biased
+// (proximity hint at the state center) since this is a CA-only demo.
+export async function geocodeAddress(address) {
+  if (!mapboxgl.accessToken) throw new Error('Mapbox token not configured')
+  const url =
+    `https://api.mapbox.com/geocoding/v5/mapbox.places/` +
+    `${encodeURIComponent(address)}.json` +
+    `?access_token=${mapboxgl.accessToken}` +
+    `&country=us&proximity=-119.5,37.0&limit=1`
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`geocode failed (${res.status})`)
+  const data = await res.json()
+  const f = data.features?.[0]
+  if (!f) throw new Error('No match for that address.')
+  return {
+    lat: f.center[1],
+    lon: f.center[0],
+    place_name: f.place_name,
+  }
+}
+
+// Stub registration call. Returns the same shape register.py returns:
+//   { resident_id, alert_radius_km, created_at }
+// Real implementation: POST {API_GATEWAY_URL}/residents/register with the
+// Cognito JWT in Authorization. Body = { phone, lat, lon, alert_radius_km }.
+export async function registerResident(payload) {
+  // Simulate latency so the loading state is visible — real API ~200-400ms.
+  await new Promise((r) => setTimeout(r, 600))
+  // Bare-bounds validation; the form already ran the full check.
+  if (!payload?.phone || (payload.lat == null && !payload.address)) {
+    throw new Error('Missing required fields.')
+  }
+  return {
+    resident_id: `stub-${Math.random().toString(36).slice(2, 10)}`,
+    alert_radius_km: payload.alert_radius_km ?? 10,
+    created_at: new Date().toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary
Right-side panel that opens when a fire is selected. **Resident view is the default** — the dispatcher view is preserved as a second tab for the AI-safety track demo.

### Resident tab (default)
The audience for a hackathon webapp can't be CalFire dispatchers (they have CAD systems and radios). It's residents and the public. This view answers three questions:

- **Are you in danger?** Alert radius, fire spread rate, containment.
- **What to do?** Evacuation route box pulled from the fire properties.
- **Has the alert gone out?** Color-coded status badge framed from the resident's perspective:
  - `<0.65` → **NO ALERT SENT** (we don't bother you unless we're sure)
  - `0.65 – 0.85` → **ALERT SENT** (flagged for audit)
  - `≥0.85` → **ALERT SENT (HIGH CONFIDENCE)** (passed Guardrails + safety gate)
- **Can I trust the AI?** Plain-language advisory + an audit-hash chip showing the SHA-style fingerprint from the hash-chained audit table — the AI Safety story made visible to residents.

### Dispatcher tab
Same content as before — incident stats, confidence-tier badge, dispatched units. Kept so the AI-safety track demo still has a place to show the Step Functions pause / auto-dispatch flow.

### Empty state
Collapsed to a small floating chip in the top-right ("Click a fire for details") so the dashboard doesn't show a 340px empty panel before any interaction.

### Theme toggle polish
Moved to the top-left and replaced with a circular sun/moon SVG icon (no emojis) so it doesn't collide with the empty-state chip.

## Architecture
Selection lives in `App.jsx`; `FireMap` and `DispatchPanel` are siblings reading the same `selectedFire`. Three deselect paths — clicking the fire again, clicking empty map, or hitting the X — all route through one setter so the evac route filter stays in sync.

`frontend/src/api/dispatch.js` is the single async entry. Confidence is deterministic per `fire_id` (FNV-1a hash → jitter) and weighted by containment so the demo naturally surfaces all three tiers across the 5 mock fires. `audit_hash` and `alert_sent_at` are stub-generated for now; real values will come from the safety-gate Lambda (#21) and the alert sender (#22) once #30 wires the API. Swap one function, panel keeps working.

## Test plan
- [ ] `npm run dev` in `frontend/`, default mode (`VITE_USE_MOCK_FIRES=true`)
- [ ] Empty state shows the small floating chip in the top-right (not a full panel)
- [ ] Theme toggle in top-left renders as moon (light mode) / sun (dark mode), animates on hover
- [ ] Click each of the 5 mock fires — Resident view loads by default
- [ ] Shasta Megafire → orange **NO ALERT SENT** badge with explanation
- [ ] Cleveland NF → green **ALERT SENT** badge, residents-notified count visible
- [ ] Audit-hash chip renders under the advisory and matches across re-renders
- [ ] Switch to Dispatcher tab — old confidence/units view still works
- [ ] Tab choice persists across fires within a session
- [ ] Theme toggle preserves the open panel and re-attaches map layers

Closes #28
🤖 Generated with [Claude Code](https://claude.com/claude-code)