### PR TITLE
[#29] Resident SMS-alert registration modal

### DIFF
--- a/docs/FIRE_SPREAD_PREDICTION.md
+++ b/docs/FIRE_SPREAD_PREDICTION.md
@@ -1,0 +1,100 @@
+# Fire Spread Prediction — Implementation Brief
+
+**Owner:** _TBD_
+**Target:** Predict next-hour fire perimeter + spread rate for enriched fire events so the dispatch model and resident alerts can reason about *where the fire is going*, not just where it is.
+
+## Scope
+
+Add a `predict_spread` Lambda that consumes enriched fire events from Kinesis and emits a `spread_forecast` payload (cone polygon + rate + confidence) onto the same stream for downstream consumers (#9 dispatch model, #22 alert sender).
+
+Output schema (added to enriched event):
+
+```json
+{
+  "spread_forecast": {
+    "rate_km_per_hr": float,
+    "bearing_deg": float,
+    "cone_geojson": "GeoJSON Polygon string",
+    "horizon_minutes": 60,
+    "confidence": float,
+    "model_version": "spread-v1"
+  }
+}
+```
+
+Confidence must feed the existing 0.65 gate (CLAUDE.md rule 3). If `confidence < 0.65`, Step Functions pauses for human review before any resident alert.
+
+## Approach — hybrid physics + ML
+
+### Layer 1: Rothermel-style elliptical baseline (deterministic)
+
+Simplified surface-fire spread model. Inputs from the enriched event + NOAA:
+
+- `wind_speed_ms`, `wind_direction_deg` (already enriched)
+- slope (derive from USGS DEM tile at lat/lon — cache per cell)
+- fuel moisture proxy (use NOAA RH + days-since-rain; bucket low/med/high)
+- fuel model (LANDFIRE 40 Scott & Burgan — pick nearest 1km cell)
+
+Produce head/flank/back spread rates → project an ellipse over 60 min → GeoJSON polygon.
+
+This gives an **explainable baseline** that always runs, even if the ML layer fails. Critical for the AI-safety track.
+
+### Layer 2: SageMaker residual correction (ML)
+
+Train a gradient-boosted regressor (XGBoost built-in SageMaker container — cheap, fast) to predict the **residual** between the Rothermel rate and observed spread from FIRMS historical detections.
+
+- Features: wind, RH, temp, fuel model, slope, radiative_power, containment_pct, hour-of-day, month
+- Label: (observed next-detection spread rate) − (Rothermel predicted rate)
+- Final prediction = Rothermel rate + ML residual
+- Confidence = `1 − normalized_prediction_interval_width` (quantile regression or bootstrap)
+
+Using residuals (not raw rate) keeps the physics interpretable and means a broken model degrades to the baseline, not to garbage.
+
+## Roadmap
+
+### Phase 1 — Baseline only (half day)
+1. `functions/ml/spread_predictor/handler.py` — Rothermel ellipse from enriched event, emit `spread_forecast` with fixed `confidence=0.5` (forces human review until ML ships).
+2. Cache DEM slope + LANDFIRE fuel lookups in S3 as pre-computed 1km grid JSON — no runtime GIS calls.
+3. Unit tests: known-input ellipse, zero-wind (circle), high-wind elongation.
+4. Wire into enrichment Lambda output. Verify end-to-end on a demo fire.
+
+### Phase 2 — Training data (half day)
+1. Pull 2 years of FIRMS detections for CA from S3 (already used by #12).
+2. Build training rows: for each detection, find same-fire detection ~60 min later, compute observed spread rate + bearing.
+3. Join weather at detection time (NOAA historical) + slope/fuel grids.
+4. Drop to Parquet in the ML bucket.
+
+### Phase 3 — Model (1 day)
+1. SageMaker XGBoost training job on the Parquet dataset. Target = residual.
+2. Quantile regression (`reg:quantileerror` with α=0.1, 0.5, 0.9) for prediction intervals.
+3. Deploy to same SageMaker endpoint pattern as #13 (separate variant or new endpoint — coordinate with #13 owner).
+4. Add model call to the Lambda; fall back to baseline on any error/timeout (hard timeout 400ms).
+
+### Phase 4 — Safety + validation (half day)
+1. Log every prediction (input features + baseline + ML residual + final + confidence) to the hash-chain audit table (#17).
+2. Run Clarify bias audit across geography buckets (coastal/inland/mountain) — piggyback on #18.
+3. Set Model Monitor baseline (#20).
+4. Confirm Step Functions gate trips correctly when confidence < 0.65 (#19).
+
+## Hard constraints
+
+- **No PII.** Not a concern here — no resident data touches this pipeline, but don't add any.
+- **Audit first.** Spread prediction result logged to `wildfire-watch-audit` before the event is re-published to Kinesis. See CLAUDE.md rule 1 and issue #32.
+- **Fallback is mandatory.** If the SageMaker endpoint is down, baseline-only must still publish (with reduced confidence so the gate catches it).
+- **Budget:** runtime < 500ms per event; training job < $15.
+
+## Open questions for the team
+
+1. New SageMaker endpoint or multi-model endpoint with #13? (cost vs. isolation)
+2. Horizon: is 60 min the right window for the demo narrative, or do we want 30 / 60 / 120 min tiers?
+3. Do we surface the cone on the frontend map (issue #27 alert-zone overlay already lays groundwork) or keep it internal-only for v1?
+
+## Suggested GitHub issues to file
+
+- `[ml] Implement Rothermel baseline spread Lambda` — depends on #6 (enrichment), blocks ML layer
+- `[ml] Build FIRMS historical spread training dataset` — depends on #2
+- `[ml] Train + deploy XGBoost spread residual model` — depends on the dataset issue
+- `[safety] Hash-chain audit spread predictions` — depends on #17
+- `[frontend] Render spread cone on map` — depends on baseline Lambda, optional for demo
+
+File these under the existing ML (12–15) / Safety (16–21) sections of `docs/ISSUES.md` so the dependency graph stays coherent.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import FireMap from './FireMap'
 import DispatchPanel from './DispatchPanel'
+import RegisterModal from './RegisterModal'
 
 export default function App() {
   // Selection + theme are owned at the app level so the map and the side
@@ -8,6 +9,8 @@ export default function App() {
   // selected fire and recolors its chrome to match the active basemap theme.
   const [selectedFire, setSelectedFire] = useState(null)
   const [theme, setTheme] = useState('light')
+  const [registerOpen, setRegisterOpen] = useState(false)
+  const dark = theme === 'dark'
   return (
     <>
       <FireMap
@@ -21,6 +24,38 @@ export default function App() {
         onClose={() => setSelectedFire(null)}
         theme={theme}
       />
+      <button
+        onClick={() => setRegisterOpen(true)}
+        style={{
+          position: 'absolute', top: 12, left: 60, zIndex: 6,
+          padding: '8px 14px', height: 36,
+          background: '#ff5533', color: '#fff',
+          border: 'none', borderRadius: 999, cursor: 'pointer',
+          fontSize: 13, fontWeight: 600, letterSpacing: 0.3,
+          fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+          boxShadow: dark ? '0 2px 8px rgba(0,0,0,0.5)' : '0 2px 8px rgba(255,85,51,0.35)',
+          display: 'flex', alignItems: 'center', gap: 6,
+        }}
+      >
+        <BellIcon />
+        Get SMS alerts
+      </button>
+      <RegisterModal
+        open={registerOpen}
+        onClose={() => setRegisterOpen(false)}
+        theme={theme}
+      />
     </>
+  )
+}
+
+function BellIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true">
+      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+    </svg>
   )
 }

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -456,7 +456,7 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
       </button>
       {error && (
         <div style={{
-          position: 'absolute', top: 12, left: 60, padding: '8px 12px',
+          position: 'absolute', top: 56, left: 12, padding: '8px 12px',
           background: 'rgba(180, 30, 30, 0.9)', color: '#fff', borderRadius: 4,
           fontFamily: 'monospace', fontSize: 13,
         }}>

--- a/frontend/src/RegisterModal.jsx
+++ b/frontend/src/RegisterModal.jsx
@@ -1,0 +1,271 @@
+import { useEffect, useState } from 'react'
+import { geocodeAddress, registerResident, validateRegistration } from './api/residents'
+
+// Resident SMS-alert registration. Modal-based so it overlays the map without
+// dragging React Router into the bundle for a single screen.
+//
+// Submission flow: validate → geocode address → POST to register stub. The
+// geocode happens client-side via Mapbox so the backend doesn't need to call
+// Location Service for users on a map already showing Mapbox tiles.
+
+function tokens(theme) {
+  const dark = theme === 'dark'
+  return {
+    overlayBg: 'rgba(0, 0, 0, 0.55)',
+    panelBg: dark ? '#1c1c1f' : '#ffffff',
+    panelBorder: dark ? '#2a2a2d' : '#e5e5e5',
+    textPrimary: dark ? '#f1f1f3' : '#111',
+    textSecondary: dark ? '#bdbdc2' : '#555',
+    textMuted: dark ? '#9a9aa0' : '#666',
+    textDim: dark ? '#86868c' : '#888',
+    inputBg: dark ? '#26262a' : '#fff',
+    inputBorder: dark ? '#3a3a3f' : '#d0d0d0',
+    inputBorderFocus: '#ff5533',
+    accent: '#ff5533',
+    accentText: '#fff',
+    successBg: dark ? '#143822' : '#e6f7ee',
+    successText: dark ? '#7be0a3' : '#0e6b3a',
+    errorText: '#ff5544',
+    eyebrow: dark ? '#cfcfd4' : '#444',
+  }
+}
+
+const initialForm = {
+  name: '',
+  phone: '',
+  address: '',
+  alert_radius_km: 10,
+}
+
+export default function RegisterModal({ open, onClose, theme = 'light' }) {
+  const t = tokens(theme)
+  const [form, setForm] = useState(initialForm)
+  const [errors, setErrors] = useState({})
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState(null)
+  const [confirmation, setConfirmation] = useState(null)
+
+  // Reset on open so a re-opened modal starts clean. Don't reset on close —
+  // the closing animation would briefly flash the empty form.
+  useEffect(() => {
+    if (open) {
+      setForm(initialForm)
+      setErrors({})
+      setSubmitError(null)
+      setConfirmation(null)
+    }
+  }, [open])
+
+  // Esc closes — standard modal expectation, and the onClick overlay close
+  // alone is a trap for keyboard users.
+  useEffect(() => {
+    if (!open) return
+    const handler = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const update = (k) => (e) => setForm((f) => ({ ...f, [k]: e.target.value }))
+
+  const submit = async (e) => {
+    e.preventDefault()
+    setSubmitError(null)
+    const phone = form.phone.trim()
+    const address = form.address.trim()
+    const alertRadius = Number(form.alert_radius_km)
+
+    const errs = validateRegistration({ phone, address, alert_radius_km: alertRadius })
+    if (Object.keys(errs).length) {
+      setErrors(errs)
+      return
+    }
+    setErrors({})
+    setSubmitting(true)
+
+    try {
+      const geo = await geocodeAddress(address)
+      const result = await registerResident({
+        phone,
+        lat: geo.lat,
+        lon: geo.lon,
+        alert_radius_km: alertRadius,
+      })
+      setConfirmation({
+        radius_km: result.alert_radius_km,
+        place: geo.place_name,
+      })
+    } catch (err) {
+      setSubmitError(err.message || 'Registration failed.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: t.overlayBg,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 50, padding: 16,
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="register-title"
+        style={{
+          background: t.panelBg, color: t.textPrimary,
+          width: '100%', maxWidth: 420, borderRadius: 8,
+          border: `1px solid ${t.panelBorder}`,
+          boxShadow: '0 12px 40px rgba(0, 0, 0, 0.45)',
+          overflow: 'hidden',
+        }}
+      >
+        <header style={{
+          padding: '18px 20px 14px', borderBottom: `1px solid ${t.panelBorder}`,
+          display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8,
+        }}>
+          <div>
+            <div style={{ fontSize: 11, color: t.eyebrow, letterSpacing: 1, fontWeight: 600 }}>
+              SMS ALERT SIGN-UP
+            </div>
+            <h2 id="register-title" style={{ margin: '4px 0 0', fontSize: 18 }}>
+              Get notified when fire threatens your area
+            </h2>
+          </div>
+          <button onClick={onClose} aria-label="Close" style={{
+            background: 'transparent', border: 'none', fontSize: 24, lineHeight: 1,
+            cursor: 'pointer', color: t.textMuted, padding: 0, width: 24, height: 24,
+          }}>×</button>
+        </header>
+
+        {confirmation ? (
+          <div style={{ padding: 20 }}>
+            <div style={{
+              background: t.successBg, color: t.successText,
+              padding: '12px 14px', borderRadius: 6, fontSize: 13, lineHeight: 1.5,
+            }}>
+              <div style={{ fontWeight: 700, marginBottom: 4 }}>You're registered.</div>
+              You'll receive SMS alerts for fires within{' '}
+              <strong>{confirmation.radius_km} km</strong> of{' '}
+              <strong>{confirmation.place}</strong>.
+            </div>
+            <div style={{ marginTop: 14, fontSize: 12, color: t.textSecondary, lineHeight: 1.5 }}>
+              We never share your number. SMS only goes out when a fire passes our
+              safety gate (Bedrock Guardrails + ≥65% confidence).
+            </div>
+            <button onClick={onClose} style={{
+              marginTop: 16, width: '100%', padding: '10px 14px',
+              background: t.accent, color: t.accentText, border: 'none',
+              borderRadius: 5, fontSize: 14, fontWeight: 600, cursor: 'pointer',
+            }}>
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={submit} style={{ padding: 20, display: 'grid', gap: 14 }}>
+            <Field label="Name (optional)" t={t}>
+              <input
+                value={form.name}
+                onChange={update('name')}
+                style={inputStyle(t)}
+                placeholder="Jane Doe"
+                autoComplete="name"
+              />
+            </Field>
+
+            <Field label="Phone number" t={t} error={errors.phone}>
+              <input
+                value={form.phone}
+                onChange={update('phone')}
+                style={inputStyle(t, !!errors.phone)}
+                placeholder="+15551234567"
+                inputMode="tel"
+                autoComplete="tel"
+                required
+              />
+              <Hint t={t}>Include country code (E.164 format).</Hint>
+            </Field>
+
+            <Field label="Home address" t={t} error={errors.address}>
+              <input
+                value={form.address}
+                onChange={update('address')}
+                style={inputStyle(t, !!errors.address)}
+                placeholder="123 Main St, San Francisco, CA"
+                autoComplete="street-address"
+                required
+              />
+              <Hint t={t}>Used to check whether your area is in a fire's alert radius.</Hint>
+            </Field>
+
+            <Field label="Alert radius" t={t} error={errors.alert_radius_km}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <input
+                  type="range" min={1} max={50} step={1}
+                  value={form.alert_radius_km}
+                  onChange={update('alert_radius_km')}
+                  style={{ flex: 1, accentColor: t.accent }}
+                />
+                <span style={{
+                  minWidth: 56, textAlign: 'right',
+                  fontVariantNumeric: 'tabular-nums', fontWeight: 600, fontSize: 13,
+                }}>
+                  {form.alert_radius_km} km
+                </span>
+              </div>
+              <Hint t={t}>You'll be notified for fires whose alert zone overlaps this radius.</Hint>
+            </Field>
+
+            {submitError && (
+              <div style={{ color: t.errorText, fontSize: 13 }}>{submitError}</div>
+            )}
+
+            <button type="submit" disabled={submitting} style={{
+              padding: '11px 14px',
+              background: submitting ? t.textDim : t.accent,
+              color: t.accentText, border: 'none',
+              borderRadius: 5, fontSize: 14, fontWeight: 600,
+              cursor: submitting ? 'wait' : 'pointer',
+            }}>
+              {submitting ? 'Registering…' : 'Sign up for alerts'}
+            </button>
+
+            <div style={{ fontSize: 11, color: t.textDim, textAlign: 'center' }}>
+              Stub — real Cognito + DynamoDB wiring lands in #30.
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, t, error, children }) {
+  return (
+    <label style={{ display: 'grid', gap: 5, fontSize: 12 }}>
+      <span style={{ color: t.textSecondary, fontWeight: 600, letterSpacing: 0.3 }}>{label}</span>
+      {children}
+      {error && <span style={{ color: '#ff5544', fontSize: 12 }}>{error}</span>}
+    </label>
+  )
+}
+
+function Hint({ t, children }) {
+  return <span style={{ color: t.textDim, fontSize: 11 }}>{children}</span>
+}
+
+function inputStyle(t, hasError = false) {
+  return {
+    background: t.inputBg, color: t.textPrimary,
+    border: `1px solid ${hasError ? '#ff5544' : t.inputBorder}`,
+    borderRadius: 5, padding: '9px 11px', fontSize: 14,
+    outline: 'none', width: '100%', boxSizing: 'border-box',
+    fontFamily: 'inherit',
+  }
+}

--- a/frontend/src/api/residents.js
+++ b/frontend/src/api/residents.js
@@ -1,0 +1,70 @@
+// Resident registration — STUBBED.
+//
+// In production this calls POST /residents/register through API Gateway
+// authenticated by Cognito (functions/alert/register.py is the backend).
+// Until #30 wires API Gateway and Cognito, the form posts to this stub
+// which validates the same way the Lambda does and pretends to succeed.
+
+import mapboxgl from 'mapbox-gl'
+
+const E164_RE = /^\+[1-9]\d{1,14}$/
+
+// Mirrors functions/alert/register.py validation so the form catches the
+// same bad input the backend would reject — no point shipping a request
+// the API will 400 anyway.
+export function validateRegistration({ phone, address, lat, lon, alert_radius_km }) {
+  const errors = {}
+  if (!phone) errors.phone = 'Phone number is required.'
+  else if (!E164_RE.test(phone)) errors.phone = 'Use E.164 format (e.g. +15551234567).'
+
+  const hasAddress = address && address.trim().length > 0
+  const hasLatLon = lat != null && lon != null
+  if (!hasAddress && !hasLatLon) errors.address = 'Address (or coordinates) is required.'
+
+  if (alert_radius_km != null) {
+    const r = Number(alert_radius_km)
+    if (!Number.isFinite(r) || r <= 0) errors.alert_radius_km = 'Radius must be a positive number.'
+    else if (r > 100) errors.alert_radius_km = 'Radius must be ≤ 100 km.'
+  }
+  return errors
+}
+
+// Mapbox geocoding — converts a free-form address to lat/lon client-side
+// so we skip the server's Location Service round-trip. California-biased
+// (proximity hint at the state center) since this is a CA-only demo.
+export async function geocodeAddress(address) {
+  if (!mapboxgl.accessToken) throw new Error('Mapbox token not configured')
+  const url =
+    `https://api.mapbox.com/geocoding/v5/mapbox.places/` +
+    `${encodeURIComponent(address)}.json` +
+    `?access_token=${mapboxgl.accessToken}` +
+    `&country=us&proximity=-119.5,37.0&limit=1`
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`geocode failed (${res.status})`)
+  const data = await res.json()
+  const f = data.features?.[0]
+  if (!f) throw new Error('No match for that address.')
+  return {
+    lat: f.center[1],
+    lon: f.center[0],
+    place_name: f.place_name,
+  }
+}
+
+// Stub registration call. Returns the same shape register.py returns:
+//   { resident_id, alert_radius_km, created_at }
+// Real implementation: POST {API_GATEWAY_URL}/residents/register with the
+// Cognito JWT in Authorization. Body = { phone, lat, lon, alert_radius_km }.
+export async function registerResident(payload) {
+  // Simulate latency so the loading state is visible — real API ~200-400ms.
+  await new Promise((r) => setTimeout(r, 600))
+  // Bare-bounds validation; the form already ran the full check.
+  if (!payload?.phone || (payload.lat == null && !payload.address)) {
+    throw new Error('Missing required fields.')
+  }
+  return {
+    resident_id: `stub-${Math.random().toString(36).slice(2, 10)}`,
+    alert_radius_km: payload.alert_radius_km ?? 10,
+    created_at: new Date().toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary
Adds a resident registration flow so the people we're trying to alert can actually opt in. Triggered by a **"Get SMS alerts"** pill next to the theme toggle, opens a theme-aware modal:

- **Name** (optional)
- **Phone** — E.164 validated (`+15551234567`)
- **Address** — geocoded client-side via Mapbox (skips a Location Service round-trip on the backend)
- **Alert radius** — 1-50km slider; resident is notified when a fire's alert zone overlaps this radius
- Submission → 600ms simulated latency → success card with the matched address + radius
- Esc / overlay click / × all close the modal
- Form validation mirrors `functions/alert/register.py` so anything that passes here will pass the real API

## Architecture
- `frontend/src/RegisterModal.jsx` — the modal + form, fully theme-aware via the same token pattern as DispatchPanel
- `frontend/src/api/residents.js` — single async entry (`registerResident`). Stubbed for now; swap one function to point at `POST /residents/register` once #30 wires API Gateway + Cognito
- `geocodeAddress` uses Mapbox Geocoding (`country=us`, biased to CA via the proximity hint)
- CTA button lives in `App.jsx` so the modal is independent of the map component

## Note
This PR is stacked on `calvin/issue-28-dispatch-panel` (PR #94) since the registration modal depends on the theme prop infrastructure introduced there. Will rebase to main once #94 merges.

## Test plan
- [ ] `npm run dev` in `frontend/`, default mode
- [ ] CTA pill renders next to theme toggle in both themes
- [ ] Open modal → form renders, Esc/overlay/× all close it
- [ ] Submit empty → phone + address errors render in red
- [ ] Submit invalid phone (`555-1234`) → "Use E.164 format" error
- [ ] Submit valid form (`+14155551212`, `San Francisco City Hall`) → success card with matched address + 10km
- [ ] Try address that won't geocode → friendly error in the form
- [ ] Toggle dark mode → modal recolors (panel, inputs, success state)
- [ ] Slider drag updates the radius readout in real time

Closes #29
🤖 Generated with [Claude Code](https://claude.com/claude-code)