### PR TITLE
[#106] Always render fire stations as available

### DIFF
--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -64,11 +64,7 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
       source: 'fire-stations',
       paint: {
         'circle-radius': 7,
-        'circle-color': [
-          'case',
-          ['==', ['get', 'available'], true], '#22cc44',
-          '#ff3322',
-        ],
+        'circle-color': '#22cc44',
         'circle-stroke-width': 1.5,
         'circle-stroke-color': '#ffffff',
       },
@@ -284,13 +280,12 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
     map.on('mouseenter', 'fire-stations-circle', (e) => {
       map.getCanvas().style.cursor = 'pointer'
       const f = e.features[0]
-      const { name, station_id, available, units } = f.properties
+      const { name, station_id, units } = f.properties
       popup
         .setLngLat(f.geometry.coordinates)
         .setHTML(
           `<strong>${name}</strong><br/>` +
           `${station_id}<br/>` +
-          `Status: ${available === true || available === 'true' ? 'available' : 'deployed'}<br/>` +
           `Units: ${units}`
         )
         .addTo(map)


### PR DESCRIPTION
## Summary
Drop the `available`/`deployed` station-state coloring in `FireMap.jsx`. Live station sync (WebSocket `resource_dispatched`, dispatcher Lambda → DynamoDB) is out of hackathon scope — the demo path is **fire → safety gate → SMS**, not visual dispatch state.

## Changes
- `FireMap.jsx`: `circle-color` case expression → fixed `#22cc44`
- `FireMap.jsx`: drop the `Status: available/deployed` line + `available` destructuring from the station hover popup

## Out of scope (per issue)
- `frontend/public/data/fire_stations.geojson` — left as-is, the `available` field is now ignored
- `frontend/src/api/websocket.js` — file doesn't exist yet; #100 plan should drop the `resource_dispatched` handler before it lands

## Test plan
- [ ] `npm run dev`, all station markers render green
- [ ] Hover a station → popup shows name / station_id / units (no Status line)
- [ ] No console errors

Closes #106
🤖 Generated with [Claude Code](https://claude.com/claude-code)