### PR TITLE
[#100] Wire useFireWebSocket into FireMap

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,3 +3,7 @@ VITE_MAPBOX_TOKEN=pk.your_mapbox_public_token_here
 # Set to "true" to render demo polygons from public/data/active_fires.geojson
 # instead of fetching live incidents from CAL FIRE. Use for the demo run.
 VITE_USE_MOCK_FIRES=false
+
+# Live update channel — fire_updated + alert_sent events from the backend.
+# Leave unset for local dev (frontend falls back to 30s polling alone).
+VITE_WS_URL=

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,6 +57,17 @@ export default function App() {
         theme={theme}
         onThemeChange={setTheme}
         onFiresLoaded={handleFiresLoaded}
+        onAlertSent={(msg) => {
+          // Real `alert_sent` from the WebSocket — supersedes the simulated
+          // driver in handleFiresLoaded for any fire it covers.
+          announcedRef.current.add(msg.fire_id)
+          setActiveAlert({
+            fire_id: msg.fire_id,
+            fire_name: msg.fire_name,
+            alerts_sent: msg.alerts_sent,
+            audit_hash: msg.audit_hash,
+          })
+        }}
       />
       <StatusPill fireCount={fireCount} lastUpdated={lastUpdated} theme={theme} />
       <AlertBanner alert={activeAlert} onDismiss={() => setActiveAlert(null)} theme={theme} />

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -3,6 +3,7 @@ import 'mapbox-gl/dist/mapbox-gl.css'
 import { useEffect, useRef, useState } from 'react'
 import { fetchActiveFires, buildAlertZones } from './api/fires'
 import { buildEvacRoutes, routeSummaryForFire } from './api/evacRoutes'
+import { useFireWebSocket } from './api/websocket'
 
 mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN
 
@@ -26,7 +27,7 @@ const STYLES = {
   dark: 'mapbox://styles/mapbox/dark-v11',
 }
 
-export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChange, onFiresLoaded }) {
+export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChange, onFiresLoaded, onAlertSent }) {
   const containerRef = useRef(null)
   const mapRef = useRef(null)
   const stationsRef = useRef(null)
@@ -264,6 +265,36 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
       setError(`fire load failed: ${e.message}`)
     }
   }
+
+  // Live patch from a `fire_updated` WebSocket message — replace the matching
+  // feature in firesRef (or append if it's a brand-new fire), recompute alert
+  // zones from the patched collection, and push both back to Mapbox without a
+  // full reload. Falls through silently if the map isn't ready yet (the next
+  // 30s polling refresh will pick it up).
+  const patchFire = (feature) => {
+    const id = feature?.properties?.fire_id
+    const map = mapRef.current
+    if (!id || !map) return
+    const current = firesRef.current?.features || []
+    const idx = current.findIndex((f) => f.properties?.fire_id === id)
+    const nextFeatures = idx >= 0
+      ? current.map((f, i) => (i === idx ? feature : f))
+      : [...current, feature]
+    const fires = { type: 'FeatureCollection', features: nextFeatures }
+    const zones = buildAlertZones(fires)
+    firesRef.current = fires
+    zonesRef.current = zones
+    if (onFiresLoaded) onFiresLoaded(fires)
+    const fireSrc = map.getSource('active-fires')
+    const zoneSrc = map.getSource('alert-zones')
+    if (fireSrc) fireSrc.setData(fires)
+    if (zoneSrc) zoneSrc.setData(zones)
+  }
+
+  useFireWebSocket({
+    onFireUpdate: patchFire,
+    onAlertSent: (msg) => onAlertSent?.(msg),
+  })
 
   useEffect(() => {
     if (mapRef.current) return

--- a/frontend/src/api/websocket.js
+++ b/frontend/src/api/websocket.js
@@ -1,0 +1,98 @@
+// Live update channel from the wildfire-watch backend.
+//
+// Subscribes to a JSON WebSocket and routes each message to the right
+// callback. Two message types are wired up today:
+//
+//   { type: 'fire_updated', fire: <GeoJSON Feature> }
+//      → backend has new perimeter / containment / acres for one fire.
+//        Frontend patches the single feature in place (no full reload).
+//
+//   { type: 'alert_sent', fire_id, fire_name, alerts_sent, audit_hash }
+//      → safety gate ran, audit row written, SMS dispatched. App lifts
+//        this into AlertBanner state.
+//
+// `resource_dispatched` was intentionally dropped — see #106. Live station
+// availability is out of hackathon scope.
+//
+// Auto-reconnect with exponential backoff (1s → 30s cap) so a transient
+// blip doesn't kill live updates for the rest of the demo session. If
+// VITE_WS_URL isn't set, the hook is a no-op so local dev keeps working
+// off the 30s polling fallback alone.
+
+import { useEffect, useRef } from 'react'
+
+const WS_URL = import.meta.env.VITE_WS_URL
+const INITIAL_RETRY_MS = 1_000
+const MAX_RETRY_MS = 30_000
+
+export function useFireWebSocket({ onFireUpdate, onAlertSent } = {}) {
+  // Keep handlers in a ref so the effect doesn't tear down/reconnect every
+  // time the parent re-renders with a new closure. We want one connection
+  // per page load.
+  const handlersRef = useRef({ onFireUpdate, onAlertSent })
+  handlersRef.current = { onFireUpdate, onAlertSent }
+
+  useEffect(() => {
+    if (!WS_URL) {
+      console.info('[ws] VITE_WS_URL not set — live updates disabled')
+      return
+    }
+
+    let cancelled = false
+    let ws = null
+    let retryTimer = null
+    let retryDelay = INITIAL_RETRY_MS
+
+    const connect = () => {
+      if (cancelled) return
+      ws = new WebSocket(WS_URL)
+
+      ws.onopen = () => {
+        console.info('[ws] connected', WS_URL)
+        retryDelay = INITIAL_RETRY_MS
+      }
+
+      ws.onmessage = (e) => {
+        let msg
+        try {
+          msg = JSON.parse(e.data)
+        } catch {
+          console.warn('[ws] dropped non-JSON payload:', e.data?.slice?.(0, 80))
+          return
+        }
+        const h = handlersRef.current
+        switch (msg.type) {
+          case 'fire_updated':
+            if (msg.fire) h.onFireUpdate?.(msg.fire)
+            break
+          case 'alert_sent':
+            h.onAlertSent?.(msg)
+            break
+          default:
+            // Forward-compatibility — log unknown types but don't error.
+            console.debug('[ws] unhandled message type:', msg.type)
+        }
+      }
+
+      ws.onclose = () => {
+        if (cancelled) return
+        retryTimer = setTimeout(connect, retryDelay)
+        retryDelay = Math.min(retryDelay * 2, MAX_RETRY_MS)
+      }
+
+      // onerror always followed by onclose; let close handle the retry.
+      ws.onerror = () => ws.close()
+    }
+
+    connect()
+
+    return () => {
+      cancelled = true
+      if (retryTimer) clearTimeout(retryTimer)
+      if (ws) {
+        ws.onclose = null   // suppress reconnect on intentional teardown
+        ws.close()
+      }
+    }
+  }, [])
+}


### PR DESCRIPTION
## Summary
Implements the live-update channel hinted at in #100. The hook didn't actually exist in any branch yet — the issue assumed it did — so this PR builds `useFireWebSocket` from scratch and wires it through.

### `frontend/src/api/websocket.js` (new)
Browser-side React hook over the WebSocket API. Two message types routed:

| Message | Action |
|---|---|
| \`{ type: 'fire_updated', fire }\` | Patch the single feature in \`firesRef\` + rebuild alert zones + \`source.setData\` for both. No full reload. |
| \`{ type: 'alert_sent', fire_id, fire_name, alerts_sent, audit_hash }\` | Bubble up to App via \`onAlertSent\` prop → drives AlertBanner. |

\`resource_dispatched\` intentionally dropped per #106 — live station availability is out of hackathon scope.

### Hook details
- **No-op when \`VITE_WS_URL\` unset** — local dev still works off the 30s polling fallback alone.
- **Exponential reconnect** (1s → 30s cap) — a transient blip doesn't kill live updates for the rest of a demo session.
- **Handlers via ref** — a parent re-render doesn't tear down and reconnect the socket every render.
- **\`onerror\` → \`onclose\`** — let close handle the retry path uniformly.

### `FireMap.jsx`
\`patchFire(feature)\` finds-or-appends by \`fire_id\`, recomputes alert zones from the patched collection, calls \`setData\` on both Mapbox sources. Silent if the map isn't ready — polling refresh catches up.

### `App.jsx`
\`onAlertSent\` lifts the WebSocket payload directly into \`activeAlert\` state (same shape AlertBanner already consumes), supersedes the simulated banner driver in \`handleFiresLoaded\` for any fire the WS covers.

### `.env.example`
Adds \`VITE_WS_URL=\` with a comment explaining the polling-fallback behavior.

## Test plan
- [ ] \`npm run dev\` with no \`VITE_WS_URL\` → console logs \"VITE_WS_URL not set — live updates disabled\"; polling still works
- [ ] Set \`VITE_WS_URL=ws://localhost:8080\` (anything that fails) → reconnects with backoff, no thrown errors
- [ ] When backend lands: send \`{type:'fire_updated', fire:<feature>}\` → matching fire's perimeter updates in place
- [ ] Send \`{type:'alert_sent', ...}\` → AlertBanner slides in with the WS payload
- [ ] No memory leak / dangling listener after navigating away

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)