### PR TITLE
[#9] Deploy enrichment Lambda — DynamoDB Streams → SageMaker

### DIFF
--- a/functions/enrich/handler.py
+++ b/functions/enrich/handler.py
@@ -450,6 +450,9 @@ def enrich_fire(fire: dict) -> dict:
 # Lambda handler
 # ------------------------------------------------------------------
 
+_NON_FIRE_PREFIXES = ("NOAA_CACHE#", "CALFIRE_STATE#")
+
+
 def handler(event, context):
     """DynamoDB Streams trigger — process INSERT records only."""
     processed = 0
@@ -465,6 +468,11 @@ def handler(event, context):
         fire = {k: list(v.values())[0] for k, v in new_image.items()}
 
         fire_id = fire.get("fire_id", "unknown")
+        # The fires table also holds NOAA weather cache + CAL FIRE dedup state
+        # rows (same primary key shape, distinguishable by fire_id prefix).
+        # Skip them — they aren't fires.
+        if any(str(fire_id).startswith(p) for p in _NON_FIRE_PREFIXES):
+            continue
         try:
             enriched = enrich_fire(fire)
             write_enriched_fire(enriched)

--- a/infrastructure/stacks/pipeline_stack.py
+++ b/infrastructure/stacks/pipeline_stack.py
@@ -1,8 +1,7 @@
-"""Pipeline stack — Kinesis → DynamoDB ingest Lambda (#8).
+"""Pipeline stack — Kinesis ingest (#8) + DynamoDB Streams enrichment (#9).
 
 Kept separate from CoreStack (which owns the data resources) and ScraperStack
-(which owns the producers) so the consumer side has a clear home. The
-enrichment Lambda (#9) will land here too once it's deployed.
+(which owns the producers) so the consumer side has a clear home.
 """
 
 import os
@@ -13,16 +12,18 @@ from aws_cdk import (
     Duration,
     aws_lambda as lambda_,
     aws_lambda_event_sources as lambda_events,
+    aws_iam as iam,
     aws_kinesis as kinesis,
     aws_dynamodb as dynamodb,
 )
 from constructs import Construct
 
 _FUNCTIONS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "functions"))
+_ENRICH_BUILD = os.path.join(_FUNCTIONS_DIR, "enrich", "build")
 
 
 class PipelineStack(Stack):
-    """Issue #8 — Kinesis consumer Lambda that writes fires to DynamoDB."""
+    """Issues #8 + #9 — Kinesis consumer + DynamoDB Streams enrichment Lambdas."""
 
     def __init__(
         self,
@@ -34,6 +35,14 @@ class PipelineStack(Stack):
     ):
         super().__init__(scope, id, **kwargs)
 
+        self._provision_ingest(fire_stream, fires_table)
+        self._provision_enrich(fires_table)
+
+    # ------------------------------------------------------------------
+    # Issue #8 — Kinesis → DynamoDB
+    # ------------------------------------------------------------------
+
+    def _provision_ingest(self, fire_stream: kinesis.Stream, fires_table: dynamodb.Table):
         ingest_fn = lambda_.Function(
             self, "IngestLambda",
             function_name="wildfire-watch-ingest",
@@ -67,3 +76,74 @@ class PipelineStack(Stack):
         )
 
         self.ingest_fn = ingest_fn
+
+    # ------------------------------------------------------------------
+    # Issue #9 — DynamoDB Streams → enrichment (NOAA + SageMaker + USGS)
+    # ------------------------------------------------------------------
+
+    def _provision_enrich(self, fires_table: dynamodb.Table):
+        # The handler imports `noaa_poller` from the scraper package; the
+        # build script (scripts/build_enrich.sh) bundles them together flat
+        # so Lambda's default sys.path picks both up.
+        enrich_fn = lambda_.Function(
+            self, "EnrichLambda",
+            function_name="wildfire-watch-enrich",
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="handler.handler",
+            code=lambda_.Code.from_asset(_ENRICH_BUILD),
+            # SageMaker invoke + NOAA HTTP + USGS HTTP serially — bound by the
+            # slowest external call rather than CPU. 60s gives plenty of slack
+            # for cold-start NOAA gridpoint resolution (two HTTP hops).
+            timeout=Duration.seconds(60),
+            memory_size=512,
+            environment={
+                "WW_DYNAMODB_FIRES_TABLE": fires_table.table_name,
+                # SageMaker endpoint defaults already match the deployed names
+                # (wildfire-watch-spread + -area). Leaving env unset would also
+                # work; setting them explicitly so a rename in #13 doesn't
+                # silently break enrichment.
+                "WW_SAGEMAKER_SPREAD_ENDPOINT": "wildfire-watch-spread",
+                "WW_SAGEMAKER_AREA_ENDPOINT": "wildfire-watch-area",
+                "WW_CONFIDENCE_THRESHOLD": "0.65",
+            },
+        )
+
+        # Read+write because (a) the handler patches enriched fields back onto
+        # the fire row via update_item, and (b) noaa_poller caches its weather
+        # responses in the same table under NOAA_CACHE#<lat,lon> keys.
+        fires_table.grant_read_write_data(enrich_fn)
+
+        # SageMaker invoke for both regression endpoints (spread + area).
+        enrich_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["sagemaker:InvokeEndpoint"],
+            resources=[
+                f"arn:aws:sagemaker:{self.region}:{self.account}:endpoint/wildfire-watch-spread",
+                f"arn:aws:sagemaker:{self.region}:{self.account}:endpoint/wildfire-watch-area",
+            ],
+        ))
+
+        # FireEnriched events feed the dispatch trigger (#10) via EventBridge.
+        enrich_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["events:PutEvents"],
+            resources=[f"arn:aws:events:{self.region}:{self.account}:event-bus/default"],
+        ))
+
+        # DynamoDB Streams trigger. INSERT-only filter happens inside the
+        # handler (the handler also skips NOAA cache + CAL FIRE state rows by
+        # fire_id prefix). Small batch + bisect_on_error keeps a poison record
+        # from blocking the shard for the whole 24h stream retention.
+        enrich_fn.add_event_source(lambda_events.DynamoEventSource(
+            fires_table,
+            starting_position=lambda_.StartingPosition.LATEST,
+            batch_size=5,
+            max_batching_window=Duration.seconds(2),
+            retry_attempts=2,
+            bisect_batch_on_error=True,
+        ))
+
+        cdk.CfnOutput(self, "EnrichLambdaArn",
+            value=enrich_fn.function_arn,
+            export_name="WildfireWatch::Pipeline::EnrichLambdaArn",
+        )
+
+        self.enrich_fn = enrich_fn

--- a/scripts/build_enrich.sh
+++ b/scripts/build_enrich.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bundle the enrichment Lambda (#9) for deployment.
+#
+# The handler imports `noaa_poller` (issue #11) which lives in the scraper
+# package, so we copy it alongside handler.py into the build dir. Lambda's
+# default sys.path includes /var/task, so a flat layout means no path tricks
+# at runtime.
+
+ENRICH_DIR="$(cd "$(dirname "$0")/../functions/enrich" && pwd)"
+SCRAPER_DIR="$(cd "$(dirname "$0")/../functions/scraper" && pwd)"
+BUILD_DIR="$ENRICH_DIR/build"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+pip install -r "$ENRICH_DIR/requirements.txt" -t "$BUILD_DIR" --quiet
+cp "$ENRICH_DIR"/*.py "$BUILD_DIR/"
+cp "$SCRAPER_DIR/noaa_poller.py" "$BUILD_DIR/"
+
+echo "Built enrich Lambda package at $BUILD_DIR"


### PR DESCRIPTION
## Summary
- New `EnrichLambda` in `PipelineStack` wired to DynamoDB Streams on the fires table.
- IAM grants: `sagemaker:InvokeEndpoint` on both deployed endpoints (`wildfire-watch-spread`, `wildfire-watch-area`), `events:PutEvents` for FireEnriched, RW on the fires table.
- New `scripts/build_enrich.sh` that bundles `handler.py` with `noaa_poller.py` (#11) and pip-installs `requests`.
- Guard in `handler.py` for NOAA cache + CAL FIRE state rows so the Lambda doesn't try to enrich its own cache writes.

## Why
Issue #9 was marked closed and the handler at `functions/enrich/handler.py` is fully written, but no CDK stack ever deployed it. DynamoDB Stream events from the fires table had no consumer, so the SageMaker endpoints (already InService) were doing nothing and `risk_score`/`spread_rate`/`confidence` never landed on any fire row. Once #112 (#8) and this PR are both merged + deployed, the chain is closed: scraper → Kinesis → ingest → DynamoDB → enrich → SageMaker → DynamoDB → /fires.

## Notes
- **Stacked on `calvin/issue-8-ingest-lambda` (PR #112).** Merge order: #112 first, rebase this on main, then merge.
- **SageMaker endpoint names verified live** via `aws sagemaker list-endpoints` — defaults match (`wildfire-watch-spread` / `wildfire-watch-area`).
- DynamoDB stream config: `batch_size=5`, `bisect_batch_on_error=True`, `retry_attempts=2`. Small batches because each record triggers a NOAA HTTP roundtrip + 2× SageMaker invokes (~1-2s end-to-end), and bisect lets a single poison record fail in isolation.
- `_NON_FIRE_PREFIXES` guard catches `NOAA_CACHE#<lat,lon>` rows written by `noaa_poller._cache_put` and `CALFIRE_STATE#<id>` rows written by `calfire_poller._save_hash`. Both share the fires table primary-key shape.

## Test plan
- [ ] `bash scripts/build_enrich.sh && cd infrastructure && cdk synth WildfireWatchPipeline` succeeds
- [ ] `cdk deploy WildfireWatchPipeline` succeeds
- [ ] After deploy, manually invoke CAL FIRE poller; within ~30s confirm a fire row in DynamoDB has `risk_score`, `wind_speed_ms`, `dispatch_recommendation` populated
- [ ] CloudWatch logs for `wildfire-watch-enrich` show `fire_id=… enriched OK risk_score=… should_dispatch=…`
- [ ] CloudWatch logs do NOT show enrichment attempts on `NOAA_CACHE#` or `CALFIRE_STATE#` records
- [ ] `/fires` endpoint surfaces non-null `risk_score` + `confidence` on returned features
- [ ] Frontend popup shows the model badge with real numbers (not the hand-faked geojson values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)