### PR TITLE
Fix CAL FIRE containment_pct unit mismatch

### DIFF
--- a/functions/scraper/calfire_poller.py
+++ b/functions/scraper/calfire_poller.py
@@ -107,7 +107,9 @@ def _normalize(feature: dict) -> dict:
         "lat": lat,
         "lon": lon,
         "perimeter_geojson": json.dumps(geometry) if geometry else None,
-        "containment_pct": float(containment_raw) / 100.0,
+        # CAL FIRE publishes a 0-100 percentage; frontend + mock data both expect
+        # 0-100 too, so pass it through without the divide-by-100 we used to do.
+        "containment_pct": float(containment_raw),
         "radiative_power": 0.0,
         "detected_at": _parse_date(
             str(props.get("StartedDateOnly") or props.get("startedDateOnly") or "")


### PR DESCRIPTION
## Summary
One-line fix: CAL FIRE publishes \`PercentContained\` as 0-100, not 0-1. The poller was dividing by 100, so a fully contained fire showed up as "1%" in the UI (Lamb Fire on the live demo).

Frontend + mock data both already expect 0-100. Drop the divide.

## Test plan
- [x] Lamb Fire renders as 100% contained after redeploy
- [x] Mock fires (which were already 0-100) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)