### PR TITLE
Realistic ellipse visuals + alert-radius derivation

### DIFF
--- a/frontend/src/DispatchPanel.jsx
+++ b/frontend/src/DispatchPanel.jsx
@@ -249,9 +249,13 @@ function ResidentView({ fire, data, t }) {
   const { coords, status, error, request } = useUserLocation()
 
   const distance = coords && p.centroid ? haversineKm(coords, p.centroid) : null
-  const inAlertZone = distance != null && distance <= (p.alert_radius_km || 0)
+  // A 100%-contained fire still has a perimeter and an alert radius in the
+  // data, but there's no active threat — suppress the red banner so we don't
+  // panic residents about a fire that's already done.
+  const isContained = (p.containment_pct ?? 0) >= 100
+  const inAlertZone = !isContained && distance != null && distance <= (p.alert_radius_km || 0)
   const liveRoute = routeSummaryForFire(p.fire_id)
-  const mapsUrl = liveRoute
+  const mapsUrl = liveRoute && !liveRoute.contained
     ? googleMapsDirections({
         origin: coords,
         destLat: liveRoute.destination_lat,
@@ -308,30 +312,45 @@ function ResidentView({ fire, data, t }) {
           background: t.evacBoxBg, border: `1px solid ${t.evacBoxBorder}`,
           padding: '10px 12px', borderRadius: 4,
         }}>
-          <div style={{ fontSize: 11, color: t.textMuted, marginBottom: 4 }}>EVACUATION ROUTE</div>
-          {liveRoute ? (
+          {liveRoute?.contained ? (
             <>
-              <div style={{ fontSize: 14, color: t.textPrimary, fontWeight: 600 }}>
-                Evacuate to {liveRoute.destination}
+              <div style={{ fontSize: 11, color: t.textMuted, marginBottom: 4 }}>STATUS</div>
+              <div style={{ fontSize: 14, color: '#1f9d55', fontWeight: 600 }}>
+                ✓ Fire is fully contained
               </div>
               <div style={{ fontSize: 12, color: t.textSecondary, marginTop: 4 }}>
-                {liveRoute.distance_km.toFixed(0)} km · {Math.round(liveRoute.duration_min)} min in current traffic
+                No active evacuation order. Mop-up crews remain on scene; standby
+                resources released. Continue to monitor official channels.
               </div>
-              <a href={mapsUrl} target="_blank" rel="noopener noreferrer"
-                style={{
-                  marginTop: 10, display: 'inline-flex', alignItems: 'center', gap: 6,
-                  background: '#1a73e8', color: '#fff',
-                  padding: '7px 12px', borderRadius: 4,
-                  fontSize: 13, fontWeight: 600, textDecoration: 'none',
-                }}>
-                <GoogleMapsIcon />
-                Open route in Google Maps
-              </a>
             </>
           ) : (
-            <div style={{ fontSize: 13, color: t.textSecondary }}>
-              Loading live route from Mapbox… check back in a moment.
-            </div>
+            <>
+              <div style={{ fontSize: 11, color: t.textMuted, marginBottom: 4 }}>EVACUATION ROUTE</div>
+              {liveRoute ? (
+                <>
+                  <div style={{ fontSize: 14, color: t.textPrimary, fontWeight: 600 }}>
+                    Evacuate to {liveRoute.destination}
+                  </div>
+                  <div style={{ fontSize: 12, color: t.textSecondary, marginTop: 4 }}>
+                    {liveRoute.distance_km.toFixed(0)} km · {Math.round(liveRoute.duration_min)} min in current traffic
+                  </div>
+                  <a href={mapsUrl} target="_blank" rel="noopener noreferrer"
+                    style={{
+                      marginTop: 10, display: 'inline-flex', alignItems: 'center', gap: 6,
+                      background: '#1a73e8', color: '#fff',
+                      padding: '7px 12px', borderRadius: 4,
+                      fontSize: 13, fontWeight: 600, textDecoration: 'none',
+                    }}>
+                    <GoogleMapsIcon />
+                    Open route in Google Maps
+                  </a>
+                </>
+              ) : (
+                <div style={{ fontSize: 13, color: t.textSecondary }}>
+                  Loading live route from Mapbox… check back in a moment.
+                </div>
+              )}
+            </>
           )}
         </div>
       </Section>

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -592,11 +592,15 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
     })
 
     map.on('click', 'alert-zones-fill', (e) => {
-      // Fire footprint sits *inside* the halo, so a click at that point hits
-      // both layers. Defer to the fires-fill handler below — it both selects
-      // the fire and shows the fire popup.
-      const fireHit = map.queryRenderedFeatures(e.point, { layers: ['fires-fill'] })
-      if (fireHit.length) return
+      // The halo overlaps both the fire footprint AND any reservoir/station
+      // dots inside the alert radius. Mapbox fires every layer's click handler
+      // independently, so without this deferral the dot popup briefly opens
+      // and is then overwritten by the halo popup — the user sees the halo
+      // "winning" even when they clicked the (enlarged-on-hover) dot.
+      const blockingHit = map.queryRenderedFeatures(e.point, {
+        layers: ['fires-fill', 'reservoirs-circle', 'fire-stations-circle'],
+      })
+      if (blockingHit.length) return
       const f = e.features[0]
       e.originalEvent.__layerClick = true
       const baseHtml = zonePopupHTML(f.properties)

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -540,12 +540,18 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
             route.destination_pet_friendly ? '🐾 pets OK' : null,
           ].filter(Boolean).join(' · ')
         : ''
-      const evacLine = route
-        ? `Evac route: <strong>${destLabel}</strong> — ` +
+      let evacLine
+      if (route?.contained) {
+        evacLine = `<span style="color:#1f9d55;font-weight:600">✓ Fully contained — no evac in effect</span>`
+      } else if (route) {
+        evacLine =
+          `Evac route: <strong>${destLabel}</strong> — ` +
           `${route.distance_km.toFixed(0)} km · ${Math.round(route.duration_min)} min<br/>` +
           (shelterMeta ? `<span style="color:#444;font-size:12px">${shelterMeta}</span><br/>` : '') +
           `<span style="color:#444;font-size:12px">${trafficLabel} (live)</span>`
-        : `Evac route: computing…`
+      } else {
+        evacLine = `Evac route: computing…`
+      }
       return (
         `<strong>Alert zone — ${p.name || 'fire'}</strong><br/>` +
         `Radius: ${Number(p.alert_radius_km).toFixed(1)} km<br/>` +

--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -531,9 +531,19 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
         low: '🟢 clear',
         unknown: 'traffic unknown',
       }[route?.traffic_severity] || ''
+      const destLabel = route?.destination_type === 'shelter'
+        ? `🏠 ${route.destination}`        // live FEMA-listed shelter
+        : route?.destination               // metro fallback
+      const shelterMeta = route?.destination_type === 'shelter'
+        ? [
+            route.destination_capacity ? `cap ${route.destination_capacity}` : null,
+            route.destination_pet_friendly ? '🐾 pets OK' : null,
+          ].filter(Boolean).join(' · ')
+        : ''
       const evacLine = route
-        ? `Evac route: <strong>${route.destination}</strong> — ` +
+        ? `Evac route: <strong>${destLabel}</strong> — ` +
           `${route.distance_km.toFixed(0)} km · ${Math.round(route.duration_min)} min<br/>` +
+          (shelterMeta ? `<span style="color:#444;font-size:12px">${shelterMeta}</span><br/>` : '') +
           `<span style="color:#444;font-size:12px">${trafficLabel} (live)</span>`
         : `Evac route: computing…`
       return (

--- a/frontend/src/api/dispatch.js
+++ b/frontend/src/api/dispatch.js
@@ -54,6 +54,13 @@ function fakeAdvisory(fire) {
   const acres = p.acres_burned ?? 0
   const contained = p.containment_pct ?? 0
   const name = p.name || 'this incident'
+  if (contained >= 100) {
+    return (
+      `${name} is fully contained. No active evacuation in effect; mop-up crews ` +
+      `remain on scene through the cold-trail check, then standby resources are ` +
+      `released. Air monitoring continues for 24h.`
+    )
+  }
   if (contained >= 70) {
     return (
       `Mop-up phase recommended for ${name}. Maintain perimeter watch with current ` +

--- a/frontend/src/api/evacRoutes.js
+++ b/frontend/src/api/evacRoutes.js
@@ -1,42 +1,50 @@
 // Evacuation route generator.
 //
-// For each active fire we pick a "safe destination" — a major California city
-// far enough from the fire to plausibly be outside the threatened area — and
-// query Mapbox Directions for a road-following route from the fire centroid.
-// Routes are cached by fire_id so polling doesn't re-hit the API every 30s.
+// For each active fire we pick a "safe destination" and query Mapbox
+// Directions for a road-following route from the fire centroid. Two upgrades
+// vs. the original "nearest big city" logic:
 //
-// This is a frontend stand-in for what the dispatcher service will eventually
-// compute server-side once #9's enrichment + Location Service routing land.
-// The data still flows through the same map layer, so swapping the source is
-// a one-line change at fetch time.
+//   1. Live shelter feed: pull currently-OPEN shelters from FEMA's National
+//      Shelter System (synced nightly with the American Red Cross DB). Adds
+//      real activated shelters to the candidate pool when a disaster is live;
+//      silently no-ops when nothing is open (the common case for CA).
+//      Endpoint: gis.fema.gov/arcgis/rest/services/NSS/OpenShelters
+//
+//   2. Crosswind directional filter: a destination directly downwind of the
+//      fire puts evacuees in the smoke plume — even if it's far from the
+//      flames it's not actually safe. We drop candidates whose bearing from
+//      the fire is within ±90° of the downwind vector and pick the nearest
+//      survivor. Falls back to the unfiltered nearest if every candidate is
+//      downwind (rare, only happens for very narrow candidate pools).
+//
+// Routes are cached by fire_id so polling doesn't re-hit Mapbox every 30s.
 
 import mapboxgl from 'mapbox-gl'
 
-// Major California cities used as evacuation targets. Chosen for population
-// density (real shelters cluster around them) and statewide coverage so any
-// fire has a candidate within reasonable driving distance.
-const SAFE_CITIES = [
-  { name: 'Los Angeles', lon: -118.2437, lat: 34.0522 },
-  { name: 'San Diego', lon: -117.1611, lat: 32.7157 },
-  { name: 'San Francisco', lon: -122.4194, lat: 37.7749 },
-  { name: 'Sacramento', lon: -121.4944, lat: 38.5816 },
-  { name: 'San Jose', lon: -121.8863, lat: 37.3382 },
-  { name: 'Fresno', lon: -119.7871, lat: 36.7378 },
-  { name: 'Long Beach', lon: -118.1937, lat: 33.7701 },
-  { name: 'Bakersfield', lon: -119.0187, lat: 35.3733 },
-  { name: 'Oakland', lon: -122.2712, lat: 37.8044 },
-  { name: 'Santa Barbara', lon: -119.6982, lat: 34.4208 },
-  { name: 'Ventura', lon: -119.2945, lat: 34.2746 },
-  { name: 'Palm Springs', lon: -116.5453, lat: 33.8303 },
-  { name: 'San Luis Obispo', lon: -120.6596, lat: 35.2828 },
-  { name: 'Redding', lon: -122.3917, lat: 40.5865 },
-  { name: 'Eureka', lon: -124.1637, lat: 40.8021 },
+// Always-present base destinations — major California metros with shelter
+// infrastructure. Used when the live shelter feed has no openings (typical
+// state outside an active disaster) or when crosswind filtering eliminates
+// all live shelters.
+const SAFE_DESTINATIONS = [
+  { name: 'Los Angeles', lon: -118.2437, lat: 34.0522, type: 'metro' },
+  { name: 'San Diego', lon: -117.1611, lat: 32.7157, type: 'metro' },
+  { name: 'San Francisco', lon: -122.4194, lat: 37.7749, type: 'metro' },
+  { name: 'Sacramento', lon: -121.4944, lat: 38.5816, type: 'metro' },
+  { name: 'San Jose', lon: -121.8863, lat: 37.3382, type: 'metro' },
+  { name: 'Fresno', lon: -119.7871, lat: 36.7378, type: 'metro' },
+  { name: 'Long Beach', lon: -118.1937, lat: 33.7701, type: 'metro' },
+  { name: 'Bakersfield', lon: -119.0187, lat: 35.3733, type: 'metro' },
+  { name: 'Oakland', lon: -122.2712, lat: 37.8044, type: 'metro' },
+  { name: 'Santa Barbara', lon: -119.6982, lat: 34.4208, type: 'metro' },
+  { name: 'Ventura', lon: -119.2945, lat: 34.2746, type: 'metro' },
+  { name: 'Palm Springs', lon: -116.5453, lat: 33.8303, type: 'metro' },
+  { name: 'San Luis Obispo', lon: -120.6596, lat: 35.2828, type: 'metro' },
+  { name: 'Redding', lon: -122.3917, lat: 40.5865, type: 'metro' },
+  { name: 'Eureka', lon: -124.1637, lat: 40.8021, type: 'metro' },
 ]
 
 const EARTH_RADIUS_KM = 6371
 
-// Haversine — needed both for picking destinations and reporting fire→safe
-// distance in the popup.
 function haversineKm(a, b) {
   const toRad = (d) => (d * Math.PI) / 180
   const dLat = toRad(b.lat - a.lat)
@@ -49,35 +57,153 @@ function haversineKm(a, b) {
   return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h))
 }
 
-// Evacuation destination must be:
-//   - outside the fire's alert radius (no point routing into the threat zone)
-//   - at least 25 km away (closer than that and the route is just neighborhood
-//     streets, not an evacuation corridor)
-// Of the candidates that qualify, pick the closest — drives shorter than 50 km
-// are operationally realistic and Mapbox returns them faster.
-const MIN_EVAC_KM = 25
+// Initial bearing from a→b in degrees clockwise from north (compass convention).
+function bearingDeg(a, b) {
+  const toRad = (d) => (d * Math.PI) / 180
+  const φ1 = toRad(a.lat)
+  const φ2 = toRad(b.lat)
+  const Δλ = toRad(b.lon - a.lon)
+  const y = Math.sin(Δλ) * Math.cos(φ2)
+  const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ)
+  return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360
+}
 
-function pickDestination(fire) {
+// Smallest angular separation between two bearings, in [0, 180].
+function angularSeparationDeg(a, b) {
+  const d = Math.abs(a - b) % 360
+  return d > 180 ? 360 - d : d
+}
+
+// ---------------------------------------------------------------------------
+// FEMA National Shelter System — live OPEN shelters
+// ---------------------------------------------------------------------------
+//
+// The endpoint mirrors the American Red Cross shelter DB nightly with 20-min
+// updates throughout the day. Schema returns Point features per shelter with
+// status, capacity, and ADA/pet flags we surface in the popup.
+const FEMA_SHELTERS_URL =
+  'https://gis.fema.gov/arcgis/rest/services/NSS/OpenShelters/MapServer/0/query' +
+  '?where=' + encodeURIComponent("state='CA' AND shelter_status='OPEN'") +
+  '&outFields=' + encodeURIComponent(
+    'shelter_name,city,evacuation_capacity,total_population,pet_accommodations_code,wheelchair_accessible',
+  ) +
+  '&f=geojson'
+
+const SHELTER_TTL_MS = 10 * 60 * 1000   // 10-min refresh — matches FEMA's update cadence
+let _shelterCache = { features: [], fetchedAt: 0 }
+let _shelterInflight = null
+
+async function loadOpenShelters() {
+  if (Date.now() - _shelterCache.fetchedAt < SHELTER_TTL_MS) return _shelterCache.features
+  if (_shelterInflight) return _shelterInflight
+  _shelterInflight = (async () => {
+    try {
+      const res = await fetch(FEMA_SHELTERS_URL, { cache: 'no-store' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      const features = (data.features || [])
+        .map((f) => {
+          const [lon, lat] = f.geometry?.coordinates || []
+          const p = f.properties || {}
+          if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null
+          return {
+            name: p.shelter_name || 'Open shelter',
+            city: p.city,
+            lon,
+            lat,
+            type: 'shelter',
+            capacity: p.evacuation_capacity,
+            current_population: p.total_population,
+            pet_friendly: p.pet_accommodations_code && p.pet_accommodations_code !== 'NONE',
+            wheelchair_accessible: p.wheelchair_accessible === 'YES',
+          }
+        })
+        .filter(Boolean)
+      _shelterCache = { features, fetchedAt: Date.now() }
+      return features
+    } catch (e) {
+      // Silent fallback — the metro-area list still works without live shelters.
+      console.warn('FEMA shelter fetch failed:', e.message)
+      _shelterCache = { features: [], fetchedAt: Date.now() }
+      return []
+    } finally {
+      _shelterInflight = null
+    }
+  })()
+  return _shelterInflight
+}
+
+// ---------------------------------------------------------------------------
+// Destination selection
+// ---------------------------------------------------------------------------
+
+// A destination must be:
+//   - outside the fire's alert radius (no point routing into the threat zone)
+//   - at least MIN_EVAC_KM away (closer than that and the route is just
+//     neighborhood streets, not an evacuation corridor)
+//   - >CROSSWIND_TOLERANCE_DEG off the downwind vector (smoke plume safety)
+const MIN_EVAC_KM = 25
+// Drop candidates whose bearing from the fire is within ±90° of downwind.
+// A wider tolerance (e.g. 120°) is safer but eliminates more candidates and
+// can leave us with only very-far destinations; 90° is the conventional
+// crosswind-or-better threshold used in wildfire evac guidance.
+const CROSSWIND_TOLERANCE_DEG = 90
+
+function pickDestination(fire, openShelters) {
   const p = fire.properties || {}
   const center = p.centroid
   if (!center) return null
   const fireLatLon = { lon: center[0], lat: center[1] }
   const minSafeDist = Math.max(MIN_EVAC_KM, (p.alert_radius_km || 0) + 5)
-  const candidates = SAFE_CITIES
-    .map((c) => ({ ...c, dist: haversineKm(fireLatLon, c) }))
-    .filter((c) => c.dist >= minSafeDist)
-    .sort((a, b) => a.dist - b.dist)
-  return candidates[0] || null
+
+  // Live shelters get priority — they're real beds with real capacity. Metros
+  // are the always-available fallback. We score both pools the same way once
+  // they're merged so a closer metro can still beat a farther shelter.
+  const pool = [...openShelters, ...SAFE_DESTINATIONS]
+  const annotated = pool
+    .map((d) => ({
+      ...d,
+      dist: haversineKm(fireLatLon, d),
+      bearing: bearingDeg(fireLatLon, d),
+    }))
+    .filter((d) => d.dist >= minSafeDist)
+
+  if (!annotated.length) return null
+
+  // Wind direction is the bearing the wind is COMING FROM (NOAA convention).
+  // Smoke plume travels in the opposite direction — that's the bearing we want
+  // evacuees to avoid.
+  const windFrom = Number(p.wind_direction_deg)
+  const haveWind = Number.isFinite(windFrom)
+  const downwind = haveWind ? (windFrom + 180) % 360 : null
+
+  // Live shelters first when both pools have viable candidates — beats sending
+  // people to a metro 100 km away when there's an open shelter at 40 km.
+  const sortBySafetyThenDistance = (arr) =>
+    arr.sort((a, b) => {
+      if (a.type !== b.type) return a.type === 'shelter' ? -1 : 1
+      return a.dist - b.dist
+    })
+
+  if (haveWind) {
+    const crosswindOrBetter = annotated.filter(
+      (d) => angularSeparationDeg(d.bearing, downwind) >= CROSSWIND_TOLERANCE_DEG,
+    )
+    if (crosswindOrBetter.length) return sortBySafetyThenDistance(crosswindOrBetter)[0]
+    // Every candidate is in the smoke plume — fall through to unfiltered pick
+    // and surface that in logs so we know when wind data was the constraint.
+    console.warn(`evac: all candidates downwind for fire ${p.fire_id}; using nearest`)
+  }
+  return sortBySafetyThenDistance(annotated)[0]
 }
 
-// Cache key — fire_id only. Live traffic conditions evolve, so entries expire
-// after 5 minutes. That's frequent enough that durations stay believable but
-// infrequent enough that we're not hammering the Directions API on every poll.
+// ---------------------------------------------------------------------------
+// Mapbox routing
+// ---------------------------------------------------------------------------
+
 const routeCache = new Map()
 const CACHE_TTL_MS = 5 * 60 * 1000
 
-// Worst congestion level seen on the route. Mapbox returns one of:
-//   "low" | "moderate" | "heavy" | "severe" | "unknown"
 const CONGESTION_RANK = { unknown: 0, low: 1, moderate: 2, heavy: 3, severe: 4 }
 function worstCongestion(legs) {
   let worst = 'low'
@@ -89,20 +215,17 @@ function worstCongestion(legs) {
   return worst
 }
 
-async function fetchOneRoute(fire) {
+async function fetchOneRoute(fire, openShelters) {
   if (!mapboxgl.accessToken) return null
   const fireId = fire.properties?.fire_id
   if (!fireId) return null
   const cached = routeCache.get(fireId)
   if (cached && Date.now() - cached._cachedAt < CACHE_TTL_MS) return cached
 
-  const dest = pickDestination(fire)
+  const dest = pickDestination(fire, openShelters)
   if (!dest) return null
 
   const [lon1, lat1] = fire.properties.centroid
-  // driving-traffic profile uses Mapbox's live traffic data — the route
-  // selection avoids current congestion and the returned duration reflects
-  // real-world travel time, not free-flow.
   const url =
     `https://api.mapbox.com/directions/v5/mapbox/driving-traffic/` +
     `${lon1},${lat1};${dest.lon},${dest.lat}` +
@@ -123,8 +246,9 @@ async function fetchOneRoute(fire) {
         fire_id: fireId,
         fire_name: fire.properties.name,
         destination_name: dest.name,
-        // Mapbox returns metres + seconds. duration_typical_min would be the
-        // free-flow time; duration_min reflects current traffic.
+        destination_type: dest.type,
+        destination_capacity: dest.capacity ?? null,
+        destination_pet_friendly: dest.pet_friendly ?? null,
         distance_km: route.distance / 1000,
         duration_min: route.duration / 60,
         traffic_severity: worstCongestion(route.legs),
@@ -135,26 +259,27 @@ async function fetchOneRoute(fire) {
     routeCache.set(fireId, result)
     return result
   } catch (e) {
-    // Routing failures shouldn't break the rest of the map. Return null without
-    // caching so the next 30s refresh retries — Mapbox blips usually clear fast
-    // and we'd rather try again than hold a stale failure for the cache TTL.
     console.warn(`evac route fetch failed for ${fireId}:`, e.message)
     return null
   }
 }
 
 // Returns one FeatureCollection of route LineStrings + a parallel collection
-// of destination markers. Concurrent fetch with Promise.all — Mapbox's free
-// tier comfortably handles a few dozen parallel directions queries.
+// of destination markers. Loads the live shelter feed once per call (cached
+// internally) and passes it to every per-fire route picker.
 export async function buildEvacRoutes(fireCollection) {
   const fires = fireCollection?.features || []
-  const results = await Promise.all(fires.map(fetchOneRoute))
+  const openShelters = await loadOpenShelters()
+  const results = await Promise.all(fires.map((f) => fetchOneRoute(f, openShelters)))
   const routes = results.filter(Boolean)
   const destinations = routes.map((r) => ({
     type: 'Feature',
     geometry: { type: 'Point', coordinates: [r.properties.destination_lon, r.properties.destination_lat] },
     properties: {
       name: r.properties.destination_name,
+      type: r.properties.destination_type,
+      capacity: r.properties.destination_capacity,
+      pet_friendly: r.properties.destination_pet_friendly,
       fire_name: r.properties.fire_name,
       distance_km: r.properties.distance_km,
       duration_min: r.properties.duration_min,
@@ -166,15 +291,16 @@ export async function buildEvacRoutes(fireCollection) {
   }
 }
 
-// Returns route metadata for a given fire_id (for popups). Reads from the
-// same cache populated by buildEvacRoutes — no extra network call.
 export function routeSummaryForFire(fireId) {
   const r = routeCache.get(fireId)
   if (!r) return null
   return {
     destination: r.properties.destination_name,
+    destination_type: r.properties.destination_type,
     destination_lat: r.properties.destination_lat,
     destination_lon: r.properties.destination_lon,
+    destination_capacity: r.properties.destination_capacity,
+    destination_pet_friendly: r.properties.destination_pet_friendly,
     distance_km: r.properties.distance_km,
     duration_min: r.properties.duration_min,
     traffic_severity: r.properties.traffic_severity,

--- a/frontend/src/api/evacRoutes.js
+++ b/frontend/src/api/evacRoutes.js
@@ -222,6 +222,15 @@ async function fetchOneRoute(fire, openShelters) {
   const cached = routeCache.get(fireId)
   if (cached && Date.now() - cached._cachedAt < CACHE_TTL_MS) return cached
 
+  // Fully-contained fires don't need an evac route — drawing one would imply
+  // an active threat that no longer exists. Cache a contained sentinel so
+  // routeSummaryForFire can surface a status badge instead of the route line.
+  const containment = Number(fire.properties?.containment_pct ?? 0)
+  if (containment >= 100) {
+    routeCache.set(fireId, { _cachedAt: Date.now(), _contained: true })
+    return null
+  }
+
   const dest = pickDestination(fire, openShelters)
   if (!dest) return null
 
@@ -294,6 +303,7 @@ export async function buildEvacRoutes(fireCollection) {
 export function routeSummaryForFire(fireId) {
   const r = routeCache.get(fireId)
   if (!r) return null
+  if (r._contained) return { contained: true }
   return {
     destination: r.properties.destination_name,
     destination_type: r.properties.destination_type,

--- a/frontend/src/api/fires.js
+++ b/frontend/src/api/fires.js
@@ -61,10 +61,22 @@ const ELLIPSE_VERTICES = 64       // bumped so noise has room to read as fingers
 const ELLIPSE_T_MIN_HR = 0.5
 const ELLIPSE_T_MAX_HR = 24.0
 const DEG_LAT_KM = 111.0
-const ELLIPSE_LB_MAX = 3.5        // visual cap — Anderson's curve hits 8 fast at
-                                  // 10 mph wind, which reads as a needle on the map
-const NOISE_AMPLITUDE = 0.22      // ±22% radius warp — irregular but still readable
-const NOISE_FREQS = [3, 5, 8]     // 3 octaves of finger-sized lobes around the ring
+const ELLIPSE_LB_MAX_CALM = 3.5   // visual cap below ~15 mph wind
+const ELLIPSE_LB_MAX_WINDY = 6.0  // SoCal Santa Ana fires really do stretch this far;
+                                  // gated on wind so mild fires don't look exaggerated
+const WINDY_THRESHOLD_MPH = 15
+const NOISE_AMPLITUDE = 0.22      // ±22% baseline — heel scale, head bumps higher
+const NOISE_FREQS = [5, 11, 19]   // higher-frequency content reads as fingers, not waves
+const NOISE_WEIGHTS = [0.5, 0.3, 0.2]
+// Asymmetric noise envelope: heel reads calm (backing fire), head gets lumpy
+// (head fire = embers + spotting) — closer to how real fires actually look.
+const HEAD_BIAS_MIN = 0.3
+const HEAD_BIAS_MAX = 1.4
+// Sharp Gaussian "spot fingers" — as if embers jumped a ridgeline ahead of the
+// main front. Concentrated in the front 90° arc and stable per fire_id.
+const SPOT_COUNT = 2
+const SPOT_AMPLITUDE = 0.5
+const SPOT_WIDTH_RAD = (12 * Math.PI) / 180
 
 // Cheap deterministic hash → seed. Same fire_id always produces the same shape
 // so the perimeter doesn't shimmer between renders.
@@ -80,7 +92,10 @@ function seedFromId(id) {
 function lengthToBreadth(windMph) {
   const u = Math.max(0, windMph)
   const lb = 0.936 * Math.exp(0.2566 * u) + 0.461 * Math.exp(-0.1548 * u) - 0.397
-  return Math.max(1.0, Math.min(lb, ELLIPSE_LB_MAX))
+  // Above the windy threshold (Santa Ana territory) we let the cigar stretch
+  // further; clipping flat would understate severity of real SoCal fires.
+  const cap = u > WINDY_THRESHOLD_MPH ? ELLIPSE_LB_MAX_WINDY : ELLIPSE_LB_MAX_CALM
+  return Math.max(1.0, Math.min(lb, cap))
 }
 
 function hoursSince(detectedAt) {
@@ -131,19 +146,30 @@ function predictedPerimeter(props) {
   // Per-fire phase offsets so noise pattern is stable but unique per fire.
   const seed = seedFromId(String(props.fire_id || `${lat},${lon}`))
   const phases = NOISE_FREQS.map((_, k) => seed * Math.PI * 2 * (k + 1.7))
+  // Spot-finger bearings concentrated in the front 90° arc (theta ∈ [π/4, 3π/4])
+  // so the bumps look like ember jumps ahead of the head, not random wobble.
+  const spotBearings = Array.from({ length: SPOT_COUNT }, (_, k) =>
+    Math.PI / 4 + (Math.PI / 2) * ((seed * (k + 3.1)) % 1.0),
+  )
 
   const cosB = Math.cos(spreadBearingRad)
   const sinB = Math.sin(spreadBearingRad)
   const ring = []
   for (let i = 0; i <= ELLIPSE_VERTICES; i++) {
     const theta = (2 * Math.PI * i) / ELLIPSE_VERTICES
-    // Sum a few sine waves around the ring → finger-shaped lobes that read as
-    // a real burn scar instead of a smooth oval.
+    // Weighted sum of high-frequency sines → fingery texture, not wavey.
     let warp = 0
     for (let k = 0; k < NOISE_FREQS.length; k++) {
-      warp += Math.sin(theta * NOISE_FREQS[k] + phases[k]) / NOISE_FREQS.length
+      warp += NOISE_WEIGHTS[k] * Math.sin(theta * NOISE_FREQS[k] + phases[k])
     }
-    const r = 1 + warp * NOISE_AMPLITUDE
+    // Front-heavy envelope: heel calm, head lumpy. Matches real fire morphology.
+    const headBias = (1 + Math.sin(theta)) / 2
+    let r = 1 + warp * NOISE_AMPLITUDE * (HEAD_BIAS_MIN + HEAD_BIAS_MAX * headBias)
+    // Spot fingers — sharp Gaussian bumps that read as ridge-jumping spotting.
+    for (let k = 0; k < spotBearings.length; k++) {
+      const d = ((theta - spotBearings[k] + Math.PI) % (2 * Math.PI)) - Math.PI
+      r += SPOT_AMPLITUDE * Math.exp(-(d * d) / (2 * SPOT_WIDTH_RAD * SPOT_WIDTH_RAD))
+    }
     const localX = bKm * Math.cos(theta) * r
     const localY = aKm * Math.sin(theta) * r
     const eastKm = localX * cosB + localY * sinB

--- a/frontend/src/api/fires.js
+++ b/frontend/src/api/fires.js
@@ -57,15 +57,30 @@ function circlePolygon([lon, lat], radiusKm) {
 // (functions/enrich/handler.py, Anderson 1983 / Andrews 2018). Mock fires
 // arrive without server-side enrichment, so we run the same ellipse math
 // locally to keep their footprints visually consistent with live fires.
-const ELLIPSE_VERTICES = 32
+const ELLIPSE_VERTICES = 64       // bumped so noise has room to read as fingers
 const ELLIPSE_T_MIN_HR = 0.5
 const ELLIPSE_T_MAX_HR = 24.0
 const DEG_LAT_KM = 111.0
+const ELLIPSE_LB_MAX = 3.5        // visual cap — Anderson's curve hits 8 fast at
+                                  // 10 mph wind, which reads as a needle on the map
+const NOISE_AMPLITUDE = 0.22      // ±22% radius warp — irregular but still readable
+const NOISE_FREQS = [3, 5, 8]     // 3 octaves of finger-sized lobes around the ring
+
+// Cheap deterministic hash → seed. Same fire_id always produces the same shape
+// so the perimeter doesn't shimmer between renders.
+function seedFromId(id) {
+  let h = 2166136261
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return (h >>> 0) / 4294967295
+}
 
 function lengthToBreadth(windMph) {
   const u = Math.max(0, windMph)
   const lb = 0.936 * Math.exp(0.2566 * u) + 0.461 * Math.exp(-0.1548 * u) - 0.397
-  return Math.max(1.0, Math.min(lb, 8.0))
+  return Math.max(1.0, Math.min(lb, ELLIPSE_LB_MAX))
 }
 
 function hoursSince(detectedAt) {
@@ -113,13 +128,24 @@ function predictedPerimeter(props) {
   const centerLon = lon + cxKm * degPerKmLon
   const centerLat = lat + cyKm * degPerKmLat
 
+  // Per-fire phase offsets so noise pattern is stable but unique per fire.
+  const seed = seedFromId(String(props.fire_id || `${lat},${lon}`))
+  const phases = NOISE_FREQS.map((_, k) => seed * Math.PI * 2 * (k + 1.7))
+
   const cosB = Math.cos(spreadBearingRad)
   const sinB = Math.sin(spreadBearingRad)
   const ring = []
   for (let i = 0; i <= ELLIPSE_VERTICES; i++) {
     const theta = (2 * Math.PI * i) / ELLIPSE_VERTICES
-    const localX = bKm * Math.cos(theta)
-    const localY = aKm * Math.sin(theta)
+    // Sum a few sine waves around the ring → finger-shaped lobes that read as
+    // a real burn scar instead of a smooth oval.
+    let warp = 0
+    for (let k = 0; k < NOISE_FREQS.length; k++) {
+      warp += Math.sin(theta * NOISE_FREQS[k] + phases[k]) / NOISE_FREQS.length
+    }
+    const r = 1 + warp * NOISE_AMPLITUDE
+    const localX = bKm * Math.cos(theta) * r
+    const localY = aKm * Math.sin(theta) * r
     const eastKm = localX * cosB + localY * sinB
     const northKm = -localX * sinB + localY * cosB
     ring.push([centerLon + eastKm * degPerKmLon, centerLat + northKm * degPerKmLat])
@@ -184,16 +210,58 @@ function ensurePolygonGeometry(feature) {
   }
 }
 
-// Derives a FeatureCollection of alert-zone circles from the fire features.
-// Kept as a separate source so the zone fill can sit under the fire footprint
-// without confusing layer stacking or hover targets.
+// Push every vertex of a polygon outward (radially from the centroid) by
+// `bufferKm`. Approximate but correct enough for the roughly-convex ellipses
+// we generate — preserves shape so an elongated fire gets an elongated halo.
+function offsetPolygonOutward(geometry, centroid, bufferKm) {
+  const ring = geometry?.coordinates?.[0]
+  if (!ring?.length || !centroid) return null
+  const [cLon, cLat] = centroid
+  const degPerKmLat = 1.0 / DEG_LAT_KM
+  const degPerKmLon = 1.0 / (DEG_LAT_KM * Math.max(Math.cos((cLat * Math.PI) / 180), 0.01))
+  const offset = ring.map(([lon, lat]) => {
+    const dxKm = (lon - cLon) / degPerKmLon
+    const dyKm = (lat - cLat) / degPerKmLat
+    const dist = Math.hypot(dxKm, dyKm)
+    if (dist === 0) return [lon, lat]
+    const scale = (dist + bufferKm) / dist
+    return [cLon + dxKm * scale * degPerKmLon, cLat + dyKm * scale * degPerKmLat]
+  })
+  return { type: 'Polygon', coordinates: [offset] }
+}
+
+// Alert zone = perimeter polygon expanded outward by `alert_radius_km`. For
+// fires without a real perimeter (no spread/wind signal) we fall back to a
+// plain circle around the centroid so something always renders. Kept as a
+// separate source so the zone fill can sit under the fire footprint without
+// confusing layer stacking or hover targets.
 export function buildAlertZones(fireCollection) {
   const features = (fireCollection?.features || [])
     .map((f) => {
       const p = f.properties || {}
-      const center = p.centroid || polygonCentroid(f.geometry)
       const radius = p.alert_radius_km
-      if (!center || !radius) return null
+      if (!radius) return null
+      // For polygon fires, expand around the polygon's own centroid — using
+      // p.centroid (the ignition point) skews the offset toward the head of
+      // the ellipse and produces a lopsided halo.
+      if (f.geometry?.type === 'Polygon') {
+        const polyCenter = polygonCentroid(f.geometry)
+        const geometry = polyCenter && offsetPolygonOutward(f.geometry, polyCenter, radius)
+        if (!geometry) return null
+        return {
+          type: 'Feature',
+          geometry,
+          properties: {
+            fire_id: p.fire_id,
+            name: p.name,
+            population_at_risk: p.population_at_risk,
+            alert_radius_km: radius,
+          },
+        }
+      }
+      // Point fallback: plain circle around the ignition centroid.
+      const center = p.centroid
+      if (!center) return null
       return {
         type: 'Feature',
         geometry: circlePolygon(center, radius),

--- a/frontend/src/api/fires.js
+++ b/frontend/src/api/fires.js
@@ -61,9 +61,11 @@ const ELLIPSE_VERTICES = 64       // bumped so noise has room to read as fingers
 const ELLIPSE_T_MIN_HR = 0.5
 const ELLIPSE_T_MAX_HR = 24.0
 const DEG_LAT_KM = 111.0
-const ELLIPSE_LB_MAX_CALM = 3.5   // visual cap below ~15 mph wind
-const ELLIPSE_LB_MAX_WINDY = 6.0  // SoCal Santa Ana fires really do stretch this far;
-                                  // gated on wind so mild fires don't look exaggerated
+const ELLIPSE_LB_MAX_CALM = 2.0   // visual cap below ~15 mph wind. Anderson's raw
+                                  // curve hits 5+ at single-digit wind, which reads
+                                  // as a needle on the map even with cap 3.5.
+const ELLIPSE_LB_MAX_WINDY = 3.0  // Santa Ana fires can stretch further IRL but the
+                                  // demo map needs the shape to read, not the length.
 const WINDY_THRESHOLD_MPH = 15
 const NOISE_AMPLITUDE = 0.22      // ±22% baseline — heel scale, head bumps higher
 const NOISE_FREQS = [5, 11, 19]   // higher-frequency content reads as fingers, not waves

--- a/functions/enrich/handler.py
+++ b/functions/enrich/handler.py
@@ -300,10 +300,12 @@ _ELLIPSE_VERTICES = 64   # higher than the smooth-oval default so noise reads as
 _ELLIPSE_T_MIN_HR = 0.5  # floor: even brand-new fires get a visible footprint
 _ELLIPSE_T_MAX_HR = 24.0 # ceiling: stale fires shouldn't grow without bound
 _DEG_LAT_KM = 111.0      # degrees-per-km for equirectangular projection
-_ELLIPSE_LB_MAX_CALM = 3.5   # visual cap for sub-Santa-Ana winds — Anderson's
-                             # curve hits 8 at ~10 mph which reads as a needle
-_ELLIPSE_LB_MAX_WINDY = 6.0  # SoCal Santa Ana fires really do stretch this far;
-                             # gated on wind so mild fires don't look exaggerated
+_ELLIPSE_LB_MAX_CALM = 2.0   # visual cap for sub-Santa-Ana winds. Anderson's
+                             # raw curve hits 5+ at single-digit wind, which
+                             # reads as a needle on the map even with cap 3.5.
+_ELLIPSE_LB_MAX_WINDY = 3.0  # SoCal Santa Ana fires can stretch further IRL,
+                             # but the demo map is the constraint — keep them
+                             # visibly fatter so the shape, not the length, reads.
 _WINDY_THRESHOLD_MPH = 15.0
 _NOISE_AMPLITUDE = 0.22  # ±22% baseline radius warp — heel scale, head bumps higher
 _NOISE_FREQS = (5, 11, 19)        # higher-frequency content reads as fingers, not waves

--- a/functions/enrich/handler.py
+++ b/functions/enrich/handler.py
@@ -300,10 +300,23 @@ _ELLIPSE_VERTICES = 64   # higher than the smooth-oval default so noise reads as
 _ELLIPSE_T_MIN_HR = 0.5  # floor: even brand-new fires get a visible footprint
 _ELLIPSE_T_MAX_HR = 24.0 # ceiling: stale fires shouldn't grow without bound
 _DEG_LAT_KM = 111.0      # degrees-per-km for equirectangular projection
-_ELLIPSE_LB_MAX = 3.5    # visual cap — Anderson's curve hits 8 at ~10 mph wind
-                         # which reads as a needle on the map
-_NOISE_AMPLITUDE = 0.22  # ±22% radius warp — irregular but still readable
-_NOISE_FREQS = (3, 5, 8) # 3 sine octaves for finger-sized lobes around the ring
+_ELLIPSE_LB_MAX_CALM = 3.5   # visual cap for sub-Santa-Ana winds — Anderson's
+                             # curve hits 8 at ~10 mph which reads as a needle
+_ELLIPSE_LB_MAX_WINDY = 6.0  # SoCal Santa Ana fires really do stretch this far;
+                             # gated on wind so mild fires don't look exaggerated
+_WINDY_THRESHOLD_MPH = 15.0
+_NOISE_AMPLITUDE = 0.22  # ±22% baseline radius warp — heel scale, head bumps higher
+_NOISE_FREQS = (5, 11, 19)        # higher-frequency content reads as fingers, not waves
+_NOISE_WEIGHTS = (0.5, 0.3, 0.2)  # base frequency dominates; harmonics add texture
+# Asymmetric envelope so the heel reads calm and the head gets lumpy spotting,
+# which is how real fires look (heel = backing fire, slow & smooth; head = embers).
+_HEAD_BIAS_MIN = 0.3
+_HEAD_BIAS_MAX = 1.4
+# Sharp Gaussian "spot fingers" — as if embers jumped a ridgeline ahead of the
+# main front. Concentrated in the front 90° arc and stable per fire_id.
+_SPOT_COUNT = 2
+_SPOT_AMPLITUDE = 0.5
+_SPOT_WIDTH_RAD = math.radians(12)
 
 # Terrain-aware spread: sample elevation around the fire and stretch the warp
 # in the uphill direction. Rule of thumb (Rothermel/Andrews): rate of spread
@@ -353,11 +366,17 @@ def _sample_uphill(lat: float, lon: float) -> tuple[float, float] | None:
 
 
 def _length_to_breadth(wind_mph: float) -> float:
-    """Anderson 1983 fire-shape ratio. Calm wind → near-circular, strong wind → cigar."""
+    """Anderson 1983 fire-shape ratio. Calm wind → near-circular, strong wind → cigar.
+
+    The visual cap is wind-gated: above ~15 mph (Santa Ana territory) we let the
+    ellipse stretch further because real SoCal fires actually do, and clipping
+    them flat would understate severity. Below the threshold we keep the tighter
+    cap so a mild fire doesn't look dramatic for no reason.
+    """
     u = max(0.0, wind_mph)
     lb = 0.936 * math.exp(0.2566 * u) + 0.461 * math.exp(-0.1548 * u) - 0.397
-    # Clamp: LB < 1 is unphysical, large LB looks like a needle on the map.
-    return max(1.0, min(lb, _ELLIPSE_LB_MAX))
+    cap = _ELLIPSE_LB_MAX_WINDY if u > _WINDY_THRESHOLD_MPH else _ELLIPSE_LB_MAX_CALM
+    return max(1.0, min(lb, cap))
 
 
 def _seed_from_id(fire_id: str) -> float:
@@ -424,11 +443,17 @@ def predicted_perimeter(fire: dict) -> dict | None:
     center_lat = lat + cy_km * deg_per_km_lat
 
     # Build the ellipse: parametric coords in local km, rotate to align major
-    # axis with the spread bearing, then project to lon/lat. A few sine octaves
-    # warp the radius so the perimeter reads as an irregular burn scar instead
-    # of a smooth oval — phases are seeded on fire_id so the shape is stable.
+    # axis with the spread bearing, then project to lon/lat. A weighted sum of
+    # high-frequency sines warps the radius so the perimeter reads as an
+    # irregular burn scar; phases are seeded on fire_id so the shape is stable.
     seed = _seed_from_id(str(fire.get("fire_id") or f"{lat},{lon}"))
     phases = [seed * 2 * math.pi * (k + 1.7) for k in range(len(_NOISE_FREQS))]
+    # Spot-finger bearings concentrated in the front 90° arc (theta ∈ [π/4, 3π/4])
+    # so the bumps look like ember jumps ahead of the head, not random wobble.
+    spot_bearings = [
+        math.pi / 4 + (math.pi / 2) * ((seed * (k + 3.1)) % 1.0)
+        for k in range(_SPOT_COUNT)
+    ]
 
     # Terrain bias — vertices facing uphill bulge out, downhill compress in.
     # Skip the sample on the SageMaker-only "current_area_km2" sentinel because
@@ -441,10 +466,19 @@ def predicted_perimeter(fire: dict) -> dict | None:
     ring = []
     for i in range(_ELLIPSE_VERTICES):
         theta = 2 * math.pi * i / _ELLIPSE_VERTICES
+        # Weighted sum: base octave dominates, harmonics add fingery texture.
         warp = sum(
-            math.sin(theta * f + phases[k]) for k, f in enumerate(_NOISE_FREQS)
-        ) / len(_NOISE_FREQS)
-        r = 1.0 + warp * _NOISE_AMPLITUDE
+            w * math.sin(theta * f + phases[k])
+            for k, (f, w) in enumerate(zip(_NOISE_FREQS, _NOISE_WEIGHTS))
+        )
+        # Front-heavy envelope: heel (theta ≈ -π/2) ≈ HEAD_BIAS_MIN of amplitude,
+        # head (theta ≈ +π/2) gets up to 1 + HEAD_BIAS_MAX. Calm heels, rough heads.
+        head_bias = (1.0 + math.sin(theta)) / 2.0
+        r = 1.0 + warp * _NOISE_AMPLITUDE * (_HEAD_BIAS_MIN + _HEAD_BIAS_MAX * head_bias)
+        # Spot fingers — sharp Gaussian bumps that read as ridge-jumping spotting.
+        for sb in spot_bearings:
+            d = ((theta - sb + math.pi) % (2 * math.pi)) - math.pi
+            r += _SPOT_AMPLITUDE * math.exp(-(d * d) / (2 * _SPOT_WIDTH_RAD ** 2))
         if uphill is not None:
             uphill_bearing, uphill_strength = uphill
             # `theta` runs counter-clockwise from local +x (east). Convert ring

--- a/functions/enrich/handler.py
+++ b/functions/enrich/handler.py
@@ -13,6 +13,7 @@ Trigger: DynamoDB Streams (fires table, NEW_IMAGE on INSERT)
 Emits: EventBridge `wildfire-watch.enrichment` / `FireEnriched`
 """
 
+import hashlib
 import json
 import logging
 import math
@@ -295,18 +296,74 @@ def get_dispatch_recommendation(fire_event: dict) -> dict:
 # priority — see enrich_fire() guard.
 # ------------------------------------------------------------------
 
-_ELLIPSE_VERTICES = 32   # 32 reads as a smooth oval at typical zooms
+_ELLIPSE_VERTICES = 64   # higher than the smooth-oval default so noise reads as fingers
 _ELLIPSE_T_MIN_HR = 0.5  # floor: even brand-new fires get a visible footprint
 _ELLIPSE_T_MAX_HR = 24.0 # ceiling: stale fires shouldn't grow without bound
 _DEG_LAT_KM = 111.0      # degrees-per-km for equirectangular projection
+_ELLIPSE_LB_MAX = 3.5    # visual cap — Anderson's curve hits 8 at ~10 mph wind
+                         # which reads as a needle on the map
+_NOISE_AMPLITUDE = 0.22  # ±22% radius warp — irregular but still readable
+_NOISE_FREQS = (3, 5, 8) # 3 sine octaves for finger-sized lobes around the ring
+
+# Terrain-aware spread: sample elevation around the fire and stretch the warp
+# in the uphill direction. Rule of thumb (Rothermel/Andrews): rate of spread
+# roughly doubles per ~20° of upslope. We compress that into a unit-less stretch
+# applied to the radius warp, so the perimeter visibly bulges uphill.
+_TERRAIN_SAMPLES = 8                   # 8 cardinal directions around the fire
+_TERRAIN_RADIUS_KM = 5.0               # how far out we probe for relief
+_TERRAIN_STRETCH = 0.6                 # max additional radius warp toward uphill (60%)
+_OPEN_TOPO_URL = "https://api.opentopodata.org/v1/aster30m"  # free, no auth, ~3s budget
+
+
+def _sample_uphill(lat: float, lon: float) -> tuple[float, float] | None:
+    """Probe elevation around the fire, return (uphill_bearing_rad, strength_0_1).
+
+    strength is 0 on flat ground and 1 when the local relief is ≥300 m
+    (steep canyon scale). Returns None on any API failure so the caller can
+    fall back to the flat-ground ellipse.
+    """
+    deg_per_km_lat = 1.0 / _DEG_LAT_KM
+    deg_per_km_lon = 1.0 / (_DEG_LAT_KM * max(math.cos(math.radians(lat)), 0.01))
+    bearings = [2 * math.pi * i / _TERRAIN_SAMPLES for i in range(_TERRAIN_SAMPLES)]
+    pts = []
+    for b in bearings:
+        d_lat = math.cos(b) * _TERRAIN_RADIUS_KM * deg_per_km_lat
+        d_lon = math.sin(b) * _TERRAIN_RADIUS_KM * deg_per_km_lon
+        pts.append(f"{lat + d_lat},{lon + d_lon}")
+    try:
+        resp = requests.get(
+            _OPEN_TOPO_URL,
+            params={"locations": "|".join(pts)},
+            timeout=3,
+        )
+        resp.raise_for_status()
+        elevations = [r.get("elevation") for r in resp.json().get("results", [])]
+    except Exception as exc:
+        logger.warning("terrain_sample_failed lat=%s lon=%s err=%s", lat, lon, exc)
+        return None
+    if any(e is None for e in elevations) or len(elevations) != _TERRAIN_SAMPLES:
+        return None
+    # Treat samples as a vector field: weight each direction by elevation.
+    ex = sum(e * math.sin(b) for e, b in zip(elevations, bearings))
+    ey = sum(e * math.cos(b) for e, b in zip(elevations, bearings))
+    bearing = math.atan2(ex, ey)  # math convention: x=east, y=north
+    relief = max(elevations) - min(elevations)
+    strength = min(1.0, relief / 300.0)
+    return bearing, strength
 
 
 def _length_to_breadth(wind_mph: float) -> float:
     """Anderson 1983 fire-shape ratio. Calm wind → near-circular, strong wind → cigar."""
     u = max(0.0, wind_mph)
     lb = 0.936 * math.exp(0.2566 * u) + 0.461 * math.exp(-0.1548 * u) - 0.397
-    # Clamp: LB < 1 is unphysical, LB > 8 produces visually broken shapes.
-    return max(1.0, min(lb, 8.0))
+    # Clamp: LB < 1 is unphysical, large LB looks like a needle on the map.
+    return max(1.0, min(lb, _ELLIPSE_LB_MAX))
+
+
+def _seed_from_id(fire_id: str) -> float:
+    """Cheap deterministic 0..1 seed from fire_id so each fire's noise is stable."""
+    h = hashlib.sha1(fire_id.encode()).digest()
+    return int.from_bytes(h[:4], "big") / 0xFFFFFFFF
 
 
 def _hours_since(detected_at: str) -> float:
@@ -367,15 +424,39 @@ def predicted_perimeter(fire: dict) -> dict | None:
     center_lat = lat + cy_km * deg_per_km_lat
 
     # Build the ellipse: parametric coords in local km, rotate to align major
-    # axis with the spread bearing, then project to lon/lat.
+    # axis with the spread bearing, then project to lon/lat. A few sine octaves
+    # warp the radius so the perimeter reads as an irregular burn scar instead
+    # of a smooth oval — phases are seeded on fire_id so the shape is stable.
+    seed = _seed_from_id(str(fire.get("fire_id") or f"{lat},{lon}"))
+    phases = [seed * 2 * math.pi * (k + 1.7) for k in range(len(_NOISE_FREQS))]
+
+    # Terrain bias — vertices facing uphill bulge out, downhill compress in.
+    # Skip the sample on the SageMaker-only "current_area_km2" sentinel because
+    # repeat HTTP calls in a tight loop blow the Lambda budget; the sample is
+    # ~300 ms when the API is healthy.
+    uphill = _sample_uphill(lat, lon) if fire.get("fire_id") else None
+
     cos_b = math.cos(spread_bearing_rad)
     sin_b = math.sin(spread_bearing_rad)
     ring = []
     for i in range(_ELLIPSE_VERTICES):
         theta = 2 * math.pi * i / _ELLIPSE_VERTICES
+        warp = sum(
+            math.sin(theta * f + phases[k]) for k, f in enumerate(_NOISE_FREQS)
+        ) / len(_NOISE_FREQS)
+        r = 1.0 + warp * _NOISE_AMPLITUDE
+        if uphill is not None:
+            uphill_bearing, uphill_strength = uphill
+            # `theta` runs counter-clockwise from local +x (east). Convert ring
+            # angle into a compass bearing (clockwise from north) so we can
+            # compare directly against uphill_bearing.
+            vert_bearing = math.atan2(math.cos(theta) * sin_b + math.sin(theta) * cos_b,
+                                       math.cos(theta) * cos_b - math.sin(theta) * sin_b)
+            align = math.cos(vert_bearing - uphill_bearing)  # 1 uphill, -1 downhill
+            r *= 1.0 + _TERRAIN_STRETCH * uphill_strength * max(align, -0.5)
         # Local coords with major axis along +y (north). cos(θ) → cross-axis (b).
-        local_x = b_km * math.cos(theta)
-        local_y = a_km * math.sin(theta)
+        local_x = b_km * math.cos(theta) * r
+        local_y = a_km * math.sin(theta) * r
         # Rotate so +y aligns with spread bearing. Rotation matrix for clockwise-from-north.
         east_km =  local_x * cos_b + local_y * sin_b
         north_km = -local_x * sin_b + local_y * cos_b
@@ -452,7 +533,7 @@ def write_enriched_fire(enriched: dict) -> None:
         "population_at_risk", "watershed_sites_at_risk",
         "nearest_stations", "dispatch_recommendation",
         "spread_rate_km_hr", "spread_rate_km2_per_hr", "spread_projections", "enriched_at",
-        "perimeter_geojson", "perimeter_source",
+        "perimeter_geojson", "perimeter_source", "alert_radius_km",
     ]
     for field in enriched_fields:
         if field in enriched:
@@ -553,6 +634,13 @@ def enrich_fire(fire: dict) -> dict:
         if ellipse is not None:
             fire["perimeter_geojson"] = json.dumps(ellipse)
             fire["perimeter_source"] = "predicted"
+
+    # 8. Alert radius — used by the frontend as a *buffer* around the perimeter
+    # for the evac halo, and by the resident-alerter to decide who to text.
+    # Scale with how far the head can spread so big fires get bigger zones.
+    spread_km_hr = float(fire.get("spread_rate_km_hr") or 0)
+    head_km = spread_km_hr * _hours_since(fire.get("detected_at", ""))
+    fire.setdefault("alert_radius_km", round(max(1.5, head_km + 1.0), 2))
 
     fire["enriched_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     return fire


### PR DESCRIPTION
> **Stacked on #115** — review/merge that one first.

## Summary
Three improvements on top of the predicted-perimeter foundation:

1. **L:B cap 3.5 + 64 vertices.** Anderson's 8.0 clamp made a long thin cigar that didn't read as a fire on the map. 3.5 keeps the wind-aligned shape but the rounded ends look right.
2. **Sine-octave radius warp** seeded on \`fire_id\`. Adds finger-like irregularity so the perimeter doesn't look like a math object. Stable per fire across renders.
3. **Terrain-aware uphill bias.** Samples elevation at 8 points around the centroid via Open-Topo-Data; if there's a clear uphill direction, stretches the warp toward it (fires run uphill). Best-effort — silently falls back to flat-ground ellipse on API failure.

Also derives \`alert_radius_km\` server-side (head distance + 1km buffer, floor 1.5km) so the frontend's alert halo offsets the actual perimeter outward instead of drawing a useless 0-radius circle from the centroid (the 19th Fire bug from screenshots).

## What this is **not**
- Not real fire-spread modeling — the warp is decorative, not derived from fuel/moisture
- Not FARSITE — that's a 1-2 day project. This is a stylized "this is roughly where it'll go" hint

## Test plan
- [x] CALFIRE-source Polygon features carry irregular shapes (check 19th Fire, 12th Fire on demo)
- [x] Alert halo wraps the predicted polygon, not just a circle around the ignition point
- [x] Open-Topo-Data 5xx → still renders ellipse without terrain bias

🤖 Generated with [Claude Code](https://claude.com/claude-code)