### PR TITLE
Fix: alert halo hijacks click on overlapping dots

### DIFF
--- a/frontend/src/FireMap.jsx
+++ b/frontend/src/FireMap.jsx
@@ -592,11 +592,15 @@ export default function FireMap({ selectedFire, onSelectFire, theme, onThemeChan
     })
 
     map.on('click', 'alert-zones-fill', (e) => {
-      // Fire footprint sits *inside* the halo, so a click at that point hits
-      // both layers. Defer to the fires-fill handler below — it both selects
-      // the fire and shows the fire popup.
-      const fireHit = map.queryRenderedFeatures(e.point, { layers: ['fires-fill'] })
-      if (fireHit.length) return
+      // The halo overlaps both the fire footprint AND any reservoir/station
+      // dots inside the alert radius. Mapbox fires every layer's click handler
+      // independently, so without this deferral the dot popup briefly opens
+      // and is then overwritten by the halo popup — the user sees the halo
+      // "winning" even when they clicked the (enlarged-on-hover) dot.
+      const blockingHit = map.queryRenderedFeatures(e.point, {
+        layers: ['fires-fill', 'reservoirs-circle', 'fire-stations-circle'],
+      })
+      if (blockingHit.length) return
       const f = e.features[0]
       e.originalEvent.__layerClick = true
       const baseHtml = zonePopupHTML(f.properties)


### PR DESCRIPTION
## Bug
When a reservoir or fire-station dot sits inside an alert halo, hovering enlarged the dot but clicking still showed the halo's popup. Mapbox fires every layer's click handler independently, so the dot's popup opened and was then immediately overwritten by the halo's popup — the halo appeared to "win" even when the user clearly aimed at the dot.

## Fix
The \`alert-zones-fill\` handler already deferred to \`fires-fill\`. Add \`reservoirs-circle\` and \`fire-stations-circle\` to the same deferral check. \`fires-fill\` already does this correctly.

## Test plan
- [x] Vite build clean
- [ ] Hover a reservoir dot inside an alert halo → click → reservoir popup stays open

🤖 Generated with [Claude Code](https://claude.com/claude-code)